### PR TITLE
chore: added documentation for developers and players

### DIFF
--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -1,0 +1,167 @@
+# API Reference — FS25_MarketDynamics
+
+Public methods for every module. All accessed via `g_MarketDynamics` and its subsystems.
+
+---
+
+## MarketDynamics (Coordinator)
+
+**Global:** `g_MarketDynamics`
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `MarketDynamics.new(modDir, modName)` | Constructor. Called once at `Mission00.load`. |
+| `onMissionLoaded` | `:onMissionLoaded(mission)` | Inits engine, registers events, sets active. |
+| `onStartMission` | `:onStartMission(mission)` | Loads savegame data via serializer. |
+| `update` | `:update(dt)` | Per-frame tick. `dt` = game-time delta in ms. |
+| `draw` | `:draw()` | Delegates HUD rendering to `g_MDMHud` if set. |
+| `save` | `:save(xmlFile)` | Persists state via serializer. |
+| `delete` | `:delete()` | Cleanup. Sets `isActive = false`. |
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `marketEngine` | `MarketEngine` | Price management subsystem |
+| `worldEvents` | `WorldEventSystem` | Event registry and scheduler |
+| `futuresMarket` | `FuturesMarket` | Contract lifecycle |
+| `serializer` | `MarketSerializer` | Save/load handler |
+| `isActive` | `boolean` | Whether the system is running |
+
+---
+
+## MarketEngine
+
+**Access:** `g_MarketDynamics.marketEngine`
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `new` | `MarketEngine.new()` | `MarketEngine` | Constructor. |
+| `init` | `:init()` | — | Snapshots base prices from game economy. Call after mission load. |
+| `update` | `:update(dt)` | — | Applies intraday and daily volatility on schedule. |
+| `getPrice` | `:getPrice(fillTypeIndex)` | `number \| nil` | Current effective price per liter for a fill type. |
+| `addModifier` | `:addModifier(modifier)` | — | Applies a named price multiplier to a fill type. |
+| `removeModifierById` | `:removeModifierById(fillTypeIndex, id)` | — | Removes a modifier by its string id. |
+
+**Modifier table:**
+
+```lua
+{
+    id            = string,   -- unique identifier (e.g. "drought_wheat")
+    fillTypeIndex = number,   -- fill type index from g_fillTypeManager
+    factor        = number,   -- price multiplier (e.g. 1.25 = +25%)
+    durationMs    = number,   -- how long the modifier lasts (game-time ms)
+}
+```
+
+Modifiers stack multiplicatively. Removing a modifier triggers `_recalculate()`.
+
+---
+
+## WorldEventSystem
+
+**Access:** `g_MarketDynamics.worldEvents`
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `new` | `WorldEventSystem.new()` | `WorldEventSystem` | Constructor. |
+| `registerEvent` | `:registerEvent(event)` | — | Registers an event type. Duplicate ids are rejected with a warning. |
+| `update` | `:update(dt)` | — | Ticks active events, checks for expiry, rolls for new events. |
+| `getActiveEvents` | `:getActiveEvents()` | `table[]` | Returns list of active event summaries (for HUD/GUI). |
+
+**Event registration table:**
+
+```lua
+{
+    id           = string,    -- unique event id (e.g. "drought")
+    name         = string,    -- display name (e.g. "Regional Drought")
+    probability  = number,    -- 0–1 chance per check interval (~5 min)
+    minIntensity = number,    -- 0–1, minimum intensity on fire
+    maxIntensity = number,    -- 0–1, maximum intensity on fire
+    cooldownMs   = number,    -- minimum ms between firings of this event
+    onFire       = function,  -- called with intensity (0–1) when event fires
+    onExpire     = function,  -- called with intensity when event expires (optional)
+}
+```
+
+**Active event summary** (returned by `getActiveEvents`):
+
+```lua
+{
+    id        = string,
+    name      = string,
+    intensity = number,   -- 0–1
+    endsAt    = number,   -- absolute game time (ms)
+}
+```
+
+---
+
+## FuturesMarket
+
+**Access:** `g_MarketDynamics.futuresMarket`
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `new` | `FuturesMarket.new()` | `FuturesMarket` | Constructor. |
+| `createContract` | `:createContract(params)` | `contractId` (number) | Creates and stores a new futures contract. |
+| `recordDelivery` | `:recordDelivery(contractId, liters)` | `boolean` | Records crop delivery toward a contract. Returns true if now fulfilled. |
+| `checkExpiry` | `:checkExpiry()` | — | Called each frame; fulfills or defaults overdue contracts. |
+| `getContractsForFarm` | `:getContractsForFarm(farmId)` | `Contract[]` | Returns all contracts for a farm (active, fulfilled, defaulted). |
+
+**Contract params table** (for `createContract`):
+
+```lua
+{
+    farmId        = number,   -- farm identifier
+    fillTypeIndex = number,   -- fill type index
+    fillTypeName  = string,   -- display name (e.g. "wheat")
+    quantity      = number,   -- contracted amount in liters
+    lockedPrice   = number,   -- price per liter at contract creation
+    deliveryTimeMs = number,  -- absolute game time deadline (ms)
+}
+```
+
+**Contract object:**
+
+```lua
+{
+    id            = number,
+    farmId        = number,
+    fillTypeIndex = number,
+    fillTypeName  = string,
+    quantity      = number,   -- total contracted liters
+    lockedPrice   = number,   -- per-liter price
+    deliveryTime  = number,   -- deadline (absolute game ms)
+    delivered     = number,   -- liters delivered so far
+    status        = string,   -- "active" | "fulfilled" | "defaulted"
+}
+```
+
+**Default penalty:** 15% of the value of the undelivered portion.
+
+---
+
+## MarketSerializer
+
+**Access:** `g_MarketDynamics.serializer`
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `MarketSerializer.new()` | Constructor. |
+| `save` | `:save(coordinator)` | Writes XML to `<savegameDir>/modSettings/FS25_MarketDynamics.xml`. |
+| `load` | `:load(coordinator)` | Reads and restores contracts + event cooldowns. No-ops gracefully if no file exists. |
+
+---
+
+## MDMLog (Logger)
+
+**Global:** `MDMLog`
+
+| Method | Description |
+|--------|-------------|
+| `MDMLog.info(msg)` | Info-level log. Prefixed `[MDM]`. |
+| `MDMLog.warn(msg)` | Warning-level log. |
+| `MDMLog.error(msg)` | Error-level log. |
+
+All output goes to `log.txt`. Filter by `[MDM]` to isolate mod output.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,210 @@
+# Architecture — FS25_MarketDynamics
+
+System design, module map, and lifecycle for the core mod (`dev-1` / tison).
+
+---
+
+## Overview
+
+MarketDynamics is a coordinator-based architecture. One global object (`g_MarketDynamics`)
+owns four subsystems and drives their update loops. Subsystems don't know about each other —
+all cross-system communication goes through the coordinator.
+
+```
+g_MarketDynamics  (MarketDynamics)
+  ├── marketEngine    MarketEngine        — price state, modifiers, volatility
+  ├── worldEvents     WorldEventSystem    — event registry, scheduling, firing
+  ├── futuresMarket   FuturesMarket       — contract lifecycle
+  └── serializer      MarketSerializer    — save/load XML
+```
+
+---
+
+## Module Load Order
+
+Defined in `main.lua`. Order is strict — each module depends on the ones above it.
+
+| # | File | Provides |
+|---|------|----------|
+| 1 | `src/Logger.lua` | `MDMLog` — logging wrapper |
+| 2 | `src/MarketEngine.lua` | `MarketEngine` class |
+| 3 | `src/WorldEventSystem.lua` | `WorldEventSystem` class |
+| 4 | `src/FuturesMarket.lua` | `FuturesMarket` class |
+| 5 | `src/MarketSerializer.lua` | `MarketSerializer` class |
+| 6 | `src/events/*.lua` | Event registrations (deferred) |
+| 7 | `src/MarketDynamics.lua` | `MarketDynamics` coordinator — **loaded last** |
+
+Event files run before the coordinator exists. They push registrations into
+`MarketDynamics.pendingEventRegistrations` (a static table), which the coordinator
+drains during `onMissionLoaded`.
+
+---
+
+## Game Hook Map
+
+| Hook | Where bound | What happens |
+|------|-------------|--------------|
+| `Mission00.load` | `main.lua` | `MarketDynamics.new()` — creates coordinator + all subsystems |
+| `Mission00.loadMission00Finished` | `main.lua` | `onMissionLoaded()` — inits engine, registers events |
+| `Mission00.onStartMission` | `main.lua` | `onStartMission()` — loads savegame XML |
+| `FSBaseMission.update` | `main.lua` | `update(dt)` — ticks all subsystems |
+| `FSBaseMission.draw` | `main.lua` | `draw()` — delegates to `g_MDMHud` if present |
+| `FSCareerMissionInfo.saveToXMLFile` | `main.lua` | `save()` — writes modSettings XML |
+| `FSBaseMission.delete` | `main.lua` | `delete()` — sets `isActive = false` |
+
+---
+
+## Lifecycle Sequence
+
+```
+game starts
+  └─ Mission00.load
+       └─ MarketDynamics.new()
+            ├─ MarketEngine.new()
+            ├─ WorldEventSystem.new()
+            ├─ FuturesMarket.new()
+            └─ MarketSerializer.new()
+
+map loads
+  └─ Mission00.loadMission00Finished
+       └─ g_MarketDynamics:onMissionLoaded()
+            ├─ marketEngine:init()          ← snapshot base prices
+            ├─ drain pendingEventRegistrations
+            └─ isActive = true
+
+savegame starts
+  └─ Mission00.onStartMission
+       └─ g_MarketDynamics:onStartMission()
+            └─ serializer:load(self)        ← restore contracts + event cooldowns
+
+per-frame
+  └─ FSBaseMission.update(dt)
+       └─ g_MarketDynamics:update(dt)
+            ├─ marketEngine:update(dt)
+            ├─ worldEvents:update(dt)
+            └─ futuresMarket:checkExpiry()
+
+per-frame
+  └─ FSBaseMission.draw()
+       └─ g_MarketDynamics:draw()
+            └─ g_MDMHud:draw()  (if present)
+
+on save
+  └─ FSCareerMissionInfo.saveToXMLFile
+       └─ g_MarketDynamics:save()
+            └─ serializer:save(self)
+
+on exit
+  └─ FSBaseMission.delete
+       └─ g_MarketDynamics:delete()
+```
+
+---
+
+## MarketEngine — Price Model
+
+Prices are stored per `fillTypeIndex`:
+
+```lua
+self.prices[fillTypeIndex] = {
+    base      = number,   -- vanilla sell price, snapshotted at init
+    current   = number,   -- base × product of all active modifiers
+    modifiers = {},       -- list of { id, factor, remaining }
+}
+```
+
+**Volatility layers (applied in update loop):**
+
+| Layer | Interval | Magnitude | Notes |
+|-------|----------|-----------|-------|
+| Intraday | 60s game-time | ±2% | Small tick noise |
+| Daily | 24h game-time | ±5% | Broader trend with mean-reversion |
+
+**Event modifiers** stack multiplicatively on top of base. When an event expires,
+its modifiers are removed and `_recalculate()` updates `current`.
+
+---
+
+## WorldEventSystem — Scheduling
+
+Every `CHECK_INTERVAL_MS` (5 in-game minutes), `_rollForEvents()` iterates the registry.
+For each event not currently active:
+
+1. Check `(now - lastFiredAt) >= cooldownMs`
+2. Roll `math.random() < event.probability`
+3. If both pass → `_fireEvent()` — sets intensity, duration, calls `event.onFire(intensity)`
+
+Only one instance of each event can be active at a time (keyed by event id).
+
+---
+
+## Event Registration Pattern
+
+Event files cannot call `WorldEventSystem:registerEvent()` directly at source time because
+`g_MarketDynamics` doesn't exist yet. Instead:
+
+```lua
+-- In any events/*.lua file:
+MarketDynamics.pendingEventRegistrations = MarketDynamics.pendingEventRegistrations or {}
+table.insert(MarketDynamics.pendingEventRegistrations, { ... })
+```
+
+The coordinator drains this table in `_registerDefaultEvents()` during `onMissionLoaded`.
+
+---
+
+## GUI Integration Point
+
+The coordinator checks for `g_MDMHud` in `draw()`. LeGrizzly's GUI sets this global.
+Core files in `src/` must not be modified by GUI branches.
+
+```lua
+-- In MarketDynamics:draw()
+if g_MDMHud then
+    g_MDMHud:draw()
+end
+```
+
+---
+
+## Save Format
+
+**Path:** `<savegameDir>/modSettings/FS25_MarketDynamics.xml`
+
+**Schema:**
+
+```xml
+<marketDynamics version="1">
+  <futures>
+    <contract id="" farmId="" fillTypeIndex="" fillTypeName=""
+              quantity="" lockedPrice="" deliveryTime=""
+              delivered="" status="" />
+  </futures>
+  <events>
+    <event id="" lastFiredAt="" />
+  </events>
+</marketDynamics>
+```
+
+Saved: active + completed futures contracts, per-event `lastFiredAt` (for cooldown persistence).
+Not saved: current price state, active event modifiers (these reset on load — by design).
+
+---
+
+## Coding Rules
+
+- **No `goto` / `continue`** — use `if/else` or early `return`
+- **No `os.time()`** — use `g_currentMission.time`
+- **No `math.sqrt` in `update()`** — use distance-squared
+- **No sliders** — use `MultiTextOption` or quick buttons
+- **Max 1500 lines per file** — split into submodules if needed
+- **Log prefix:** `[MDM]` (via `MDMLog`)
+
+---
+
+## See Also
+
+- [API Reference](api-reference.md) — Public methods per module
+- [Event Authoring](event-authoring.md) — Adding new event types
+- [Serialization](serialization.md) — Save/load internals
+- [Lua Compatibility](lua-compat.md) — Lua 5.1 / FS25 gotchas

--- a/docs/dev/event-authoring.md
+++ b/docs/dev/event-authoring.md
@@ -1,0 +1,179 @@
+# Event Authoring — Adding New World Events
+
+How to create, register, and test a new event type for FS25_MarketDynamics.
+
+---
+
+## Event Anatomy
+
+An event is a Lua file in `src/events/` that:
+
+1. Defines `onFire(intensity)` — what happens when the event triggers
+2. Defines `onExpire(intensity)` — cleanup when the event ends
+3. Pushes a registration table into `MarketDynamics.pendingEventRegistrations`
+
+The coordinator processes all pending registrations during `onMissionLoaded`. This
+deferred pattern exists because event files are sourced before `g_MarketDynamics` exists.
+
+---
+
+## Minimal Template
+
+```lua
+-- src/events/MyEvent.lua
+-- Brief description of what this event represents.
+--
+-- Author: yourname
+
+local EVENT_ID = "my_event"  -- must be globally unique
+
+local AFFECTED_CROPS = { "wheat", "barley" }  -- lowercase fill type names
+
+local function onFire(intensity)
+    if not g_MarketDynamics then return end
+
+    -- intensity is 0–1, interpolate to your desired price range
+    local factor = 1.10 + intensity * 0.20  -- e.g. 1.10x to 1.30x
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName:upper())
+        if fillType then
+            g_MarketDynamics.marketEngine:addModifier({
+                id            = EVENT_ID .. "_" .. cropName,
+                fillTypeIndex = fillType.index,
+                factor        = factor,
+                durationMs    = 10 * 60 * 1000,  -- 10 in-game minutes
+            })
+        end
+    end
+
+    MDMLog.info("MyEvent fired — factor " .. string.format("%.2f", factor))
+end
+
+local function onExpire(intensity)
+    if not g_MarketDynamics then return end
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName:upper())
+        if fillType then
+            g_MarketDynamics.marketEngine:removeModifierById(
+                fillType.index,
+                EVENT_ID .. "_" .. cropName
+            )
+        end
+    end
+end
+
+-- Deferred registration
+MarketDynamics.pendingEventRegistrations = MarketDynamics.pendingEventRegistrations or {}
+table.insert(MarketDynamics.pendingEventRegistrations, {
+    id           = EVENT_ID,
+    name         = "My Event Display Name",
+    probability  = 0.07,          -- 7% chance per 5-min check
+    minIntensity = 0.2,
+    maxIntensity = 1.0,
+    cooldownMs   = 30 * 60 * 1000,
+    onFire       = onFire,
+    onExpire     = onExpire,
+})
+```
+
+---
+
+## Registration Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✓ | Unique event identifier. Used as key in registry + active table. |
+| `name` | string | ✓ | Human-readable display name (shown in HUD). |
+| `probability` | number | ✓ | Chance of firing per check (every 5 in-game minutes). 0.08 = 8%. |
+| `minIntensity` | number | ✓ | Minimum intensity value (0–1). Recommend ≥ 0.2. |
+| `maxIntensity` | number | ✓ | Maximum intensity value (0–1). |
+| `cooldownMs` | number | ✓ | Minimum gap (game ms) before this event can fire again. |
+| `onFire` | function | ✓ | Called with `intensity` (0–1) when event fires. |
+| `onExpire` | function | — | Called with `intensity` when event expires. Include to clean up modifiers. |
+
+---
+
+## Intensity Mapping
+
+Intensity is a `0–1` float, randomized between `minIntensity` and `maxIntensity` on each fire.
+Map it to a price factor in `onFire`:
+
+```lua
+-- Price boost event (+10% to +35%)
+local factor = 1.10 + intensity * 0.25
+
+-- Price crash event (-8% to -25%)
+local factor = 0.92 - intensity * 0.17
+
+-- Mixed / asymmetric (two crop groups)
+local stapleFactor = 1.15 + intensity * 0.30  -- +15% to +45%
+local energyFactor = 1.20 + intensity * 0.35  -- +20% to +55%
+```
+
+Modifiers stack multiplicatively in MarketEngine. If two events affect the same crop
+simultaneously, both factors multiply together.
+
+---
+
+## Modifier ID Convention
+
+Modifier ids must be unique per fill type to allow clean removal:
+
+```lua
+id = EVENT_ID .. "_" .. cropName
+-- e.g. "my_event_wheat", "my_event_barley"
+```
+
+The same id is used in both `addModifier` and `removeModifierById`. If you use different
+ids in `onFire` and `onExpire`, the modifier will not be removed — double-check these match.
+
+---
+
+## Loading the File
+
+Add the event file to `main.lua` **before** `src/MarketDynamics.lua`:
+
+```lua
+source(modDir .. "src/events/BumperHarvestEvent.lua")
+source(modDir .. "src/events/DroughtEvent.lua")
+source(modDir .. "src/events/GeopoliticalEvent.lua")
+source(modDir .. "src/events/TradeDisruptionEvent.lua")
+source(modDir .. "src/events/MyEvent.lua")         -- ← add here
+source(modDir .. "src/MarketDynamics.lua")
+```
+
+---
+
+## Probability & Balance Reference
+
+Existing events as a balance baseline:
+
+| Event | Probability | Cooldown | Price Range | Duration |
+|-------|-------------|----------|-------------|----------|
+| Drought | 8% | 30 min | +10–35% | 15 min |
+| Bumper Harvest | 10% | 25 min | -8–25% | 12 min |
+| Trade Disruption | 6% | 40 min | +5–25% | 8 min |
+| Geopolitical Crisis | 4% | 60 min | +15–55% | 20 min |
+
+Guidelines:
+- **High-impact events** (>30% swing): keep probability ≤ 5% and cooldown ≥ 45 min
+- **Moderate events**: 6–10% probability, 20–35 min cooldown
+- **Duration**: keep between 5–25 in-game minutes; very long durations distort the economy
+
+---
+
+## Testing
+
+1. Deploy with `bash build.sh --deploy`
+2. Start a new game, open `log.txt`
+3. Filter for `[MDM]` — you'll see registration on startup and event firings in-session
+4. Temporarily raise `probability` to `1.0` for immediate testing, then restore it
+
+---
+
+## See Also
+
+- [Architecture](architecture.md) — Event registration lifecycle explained
+- [API Reference](api-reference.md) — `WorldEventSystem` and `MarketEngine` method signatures

--- a/docs/dev/lua-compat.md
+++ b/docs/dev/lua-compat.md
@@ -1,0 +1,144 @@
+# Lua Compatibility — FS25 / Lua 5.1 Gotchas
+
+FS25 runs Lua 5.1. Several patterns from modern Lua or other languages don't work.
+This page documents what breaks and what to use instead.
+
+---
+
+## Language Restrictions
+
+### No `goto` / `continue`
+
+`goto` was introduced in Lua 5.2. FS25 doesn't have it.
+
+```lua
+-- BROKEN
+for i = 1, 10 do
+    if someCondition then goto continue end
+    doWork(i)
+    ::continue::
+end
+
+-- CORRECT — use if/else or early return
+for i = 1, 10 do
+    if not someCondition then
+        doWork(i)
+    end
+end
+```
+
+### No `os.time()` / `os.date()`
+
+The FS25 sandbox blocks OS time functions. Use game time instead.
+
+```lua
+-- BROKEN
+local now = os.time()
+
+-- CORRECT
+local now = g_currentMission and g_currentMission.time or 0
+```
+
+`g_currentMission.time` is in milliseconds of in-game time elapsed since mission start.
+
+---
+
+## FS25 API Restrictions
+
+### No Slider Widgets
+
+Slider UI elements don't function correctly in FS25. Use alternatives:
+
+```lua
+-- BROKEN
+local slider = self.root:getDescendantByName("mySlider")
+
+-- CORRECT — use MultiTextOption for discrete steps
+local option = self.root:getDescendantByName("myOption")
+-- or use simple +/- button pairs
+```
+
+### `imageFilename` Doesn't Work for Mod Images in XML
+
+Setting `imageFilename` in XML layout for mod-local images silently fails.
+Set it in code instead:
+
+```lua
+-- BROKEN (in XML): imageFilename="$l10n_..."
+
+-- CORRECT (in Lua onCreate callback):
+local img = self.root:getDescendantByName("myImage")
+img:setImageFilename(self.modDirectory .. "gui/textures/myIcon.png")
+```
+
+### `setTextColorByName()` Doesn't Exist
+
+```lua
+-- BROKEN
+label:setTextColorByName("red")
+
+-- CORRECT
+label:setTextColor(1, 0, 0, 1)  -- r, g, b, a
+```
+
+---
+
+## Performance Rules
+
+### No `math.sqrt` in `update()`
+
+Square root is expensive and called every frame. Use distance-squared comparisons.
+
+```lua
+-- BROKEN — in update()
+local dist = math.sqrt((x2-x1)^2 + (y2-y1)^2)
+if dist < threshold then ...
+
+-- CORRECT
+local distSq = (x2-x1)^2 + (y2-y1)^2
+if distSq < threshold * threshold then ...
+```
+
+---
+
+## FS25 Global APIs — Check Before Using
+
+Always verify these in the reference docs before use. APIs change between FS versions
+and community docs may lag behind.
+
+| API | Notes |
+|-----|-------|
+| `g_currentMission.*` | Check field exists — not all fields present in all mission states |
+| `g_fillTypeManager` | Safe after `loadMission00Finished`; not available during `load` |
+| `g_farmManager` | Same timing as above |
+| `g_currentMission.economyManager` | Available post-load; use for base price queries |
+| `SellingStation` | Check community LUADOC for current sell price method signatures |
+| `MoneyType` | Check valid enum values — `MoneyType.OTHER` is safe for custom payouts |
+| GUI/dialog system | Highly version-sensitive; always test in-game |
+
+Reference paths (local to development machine):
+- `C:\Users\tison\Desktop\FS25 MODS\FS25-Community-LUADOC`
+- `C:\Users\tison\Desktop\FS25 MODS\FS25-lua-scripting`
+
+---
+
+## Quick Reference Table
+
+| Pattern | Broken | Use Instead |
+|---------|--------|-------------|
+| `goto` / `continue` | ✗ | `if/else` or early `return` |
+| `os.time()` | ✗ | `g_currentMission.time` |
+| `os.date()` | ✗ | Not available; derive from game time |
+| Slider widgets | ✗ | `MultiTextOption` or ± buttons |
+| XML `imageFilename` for mod assets | ✗ | `setImageFilename()` in `onCreate()` |
+| `setTextColorByName()` | ✗ | `setTextColor(r, g, b, a)` |
+| `math.sqrt` in `update()` | ⚠ slow | Distance-squared comparison |
+| Bitwise operators (`&`, `\|`, `~`) | ✗ | `bit.band()`, `bit.bor()`, `bit.bnot()` |
+| Integer division `//` | ✗ | `math.floor(a / b)` |
+
+---
+
+## See Also
+
+- [Architecture](architecture.md) — Game hook patterns and safe API usage timing
+- [Event Authoring](event-authoring.md) — Safe patterns used in existing events

--- a/docs/dev/serialization.md
+++ b/docs/dev/serialization.md
@@ -1,0 +1,154 @@
+# Serialization — Save/Load System
+
+How FS25_MarketDynamics persists and restores market state across game sessions.
+
+---
+
+## Save File Location
+
+```
+<savegameDirectory>/modSettings/FS25_MarketDynamics.xml
+```
+
+The `savegameDirectory` is provided by `g_currentMission.missionInfo.savegameDirectory`.
+Each FS25 savegame slot has its own `modSettings/` folder, so state is per-save.
+
+---
+
+## What Is Saved
+
+| Data | Saved | Notes |
+|------|-------|-------|
+| Futures contracts | ✓ | All statuses: active, fulfilled, defaulted |
+| Event `lastFiredAt` | ✓ | Preserves cooldown state across sessions |
+| Current crop prices | ✗ | Recalculated fresh on load |
+| Active event modifiers | ✗ | Events reset on session start (by design) |
+
+Price state is intentionally not persisted — it recalculates from vanilla base prices
+on each `MarketEngine:init()`. This keeps saves forward-compatible if price logic changes.
+
+---
+
+## XML Schema
+
+```xml
+<marketDynamics version="1">
+
+  <futures>
+    <contract
+      id="1"
+      farmId="1"
+      fillTypeIndex="3"
+      fillTypeName="wheat"
+      quantity="20000"
+      lockedPrice="2.50"
+      deliveryTime="345600000"
+      delivered="12000"
+      status="active"
+    />
+    <!-- additional contracts... -->
+  </futures>
+
+  <events>
+    <event id="drought"         lastFiredAt="123456000" />
+    <event id="bumper_harvest"  lastFiredAt="98765000"  />
+    <!-- one entry per registered event -->
+  </events>
+
+</marketDynamics>
+```
+
+**Version field:** Currently `"1"`. Increment if schema changes break backward compatibility.
+Future loaders should handle older versions gracefully.
+
+---
+
+## Save Flow
+
+Triggered by `FSCareerMissionInfo.saveToXMLFile` → `g_MarketDynamics:save()` →
+`MarketSerializer:save(coordinator)`.
+
+```lua
+-- Simplified save flow:
+local xmlFile = createXMLFile("MDMSave", path, "marketDynamics")
+setXMLString(xmlFile, "marketDynamics#version", "1")
+
+-- Write each contract
+for _, contract in pairs(coordinator.futuresMarket.contracts) do
+    setXMLInt   (xmlFile, base .. "#id",            contract.id)
+    setXMLString(xmlFile, base .. "#status",        contract.status)
+    -- ... all fields
+end
+
+-- Write event cooldown state
+for id, event in pairs(coordinator.worldEvents.registry) do
+    setXMLFloat(xmlFile, base .. "#lastFiredAt", event.lastFiredAt)
+end
+
+saveXMLFile(xmlFile)
+delete(xmlFile)
+```
+
+---
+
+## Load Flow
+
+Triggered by `Mission00.onStartMission` → `g_MarketDynamics:onStartMission()` →
+`MarketSerializer:load(coordinator)`.
+
+```lua
+-- Simplified load flow:
+local xmlFile = loadXMLFile("MDMLoad", path)
+if not xmlFile then return end  -- no save file = fresh start, not an error
+
+-- Restore contracts
+local i = 0
+while true do
+    local id = getXMLInt(xmlFile, base .. "#id")
+    if not id then break end
+    coordinator.futuresMarket.contracts[id] = { ... }
+    -- also updates futuresMarket.nextId to avoid id collisions
+    i = i + 1
+end
+
+-- Restore event cooldowns
+local j = 0
+while true do
+    local evId = getXMLString(xmlFile, base .. "#id")
+    if not evId then break end
+    coordinator.worldEvents.registry[evId].lastFiredAt = lastFired
+    j = j + 1
+end
+
+delete(xmlFile)
+```
+
+If the file doesn't exist (new game, or first session after installing the mod),
+`loadXMLFile` returns nil and `load()` returns silently — this is expected.
+
+---
+
+## Adding Fields to the Schema
+
+If you add new state that needs persistence:
+
+1. Add `setXML*` calls in `MarketSerializer:save()` for the new field
+2. Add matching `getXML*` calls in `MarketSerializer:load()`
+3. Handle the missing-field case gracefully in load (old saves won't have the field)
+4. Increment the version string if the change is breaking
+
+**FS25 XML API:**
+
+| Function | Type |
+|----------|------|
+| `setXMLString` / `getXMLString` | string |
+| `setXMLInt` / `getXMLInt` | integer |
+| `setXMLFloat` / `getXMLFloat` | float |
+| `setXMLBool` / `getXMLBool` | boolean |
+
+---
+
+## See Also
+
+- [Architecture](architecture.md) — Full lifecycle including save/load hooks
+- [API Reference](api-reference.md) — `MarketSerializer` method signatures

--- a/docs/gui/data-queries.md
+++ b/docs/gui/data-queries.md
@@ -1,0 +1,129 @@
+# Data Queries — Reading Prices, Events, and Contracts
+
+All public APIs available to the GUI layer. Never access subsystem internals directly.
+
+---
+
+## Guard First
+
+Always check before querying — the core may not be active during loading:
+
+```lua
+if not g_MarketDynamics or not g_MarketDynamics.isActive then return end
+```
+
+---
+
+## Crop Prices
+
+```lua
+-- Get current effective price per liter for a fill type
+-- Returns number or nil if fill type is unknown to the engine
+local price = g_MarketDynamics.marketEngine:getPrice(fillTypeIndex)
+```
+
+To get a `fillTypeIndex` from a crop name:
+
+```lua
+local fillType = g_fillTypeManager:getFillTypeByName("WHEAT")  -- uppercase
+local index = fillType and fillType.index
+```
+
+---
+
+## Active World Events
+
+```lua
+-- Returns a list of currently active event summaries
+local events = g_MarketDynamics.worldEvents:getActiveEvents()
+
+-- Each entry:
+-- {
+--   id        = string,   -- event id (e.g. "drought")
+--   name      = string,   -- display name (e.g. "Regional Drought")
+--   intensity = number,   -- 0–1 (how severe)
+--   endsAt    = number,   -- absolute game time (ms) when event expires
+-- }
+
+if #events == 0 then
+    -- show "Markets stable" / mdm_hud_no_events
+end
+
+-- Time remaining for an event
+local now = g_currentMission and g_currentMission.time or 0
+local remaining = event.endsAt - now  -- ms remaining
+```
+
+---
+
+## Futures Contracts
+
+```lua
+-- Returns all contracts for a farm (active, fulfilled, defaulted)
+local farmId = g_currentMission.player.farmId  -- or however you resolve current farm
+local contracts = g_MarketDynamics.futuresMarket:getContractsForFarm(farmId)
+
+-- Each contract:
+-- {
+--   id            = number,
+--   farmId        = number,
+--   fillTypeIndex = number,
+--   fillTypeName  = string,   -- e.g. "wheat"
+--   quantity      = number,   -- total contracted liters
+--   lockedPrice   = number,   -- per-liter price locked in
+--   deliveryTime  = number,   -- deadline (absolute game ms)
+--   delivered     = number,   -- liters delivered so far
+--   status        = string,   -- "active" | "fulfilled" | "defaulted"
+-- }
+
+-- Delivery progress
+local pct = contract.delivered / contract.quantity  -- 0.0 to 1.0+
+
+-- Time to deadline
+local now = g_currentMission and g_currentMission.time or 0
+local timeLeft = contract.deliveryTime - now  -- ms; negative = overdue
+```
+
+---
+
+## Creating a Contract (from GUI)
+
+```lua
+-- Call when player confirms a new contract in the UI
+local contractId = g_MarketDynamics.futuresMarket:createContract({
+    farmId         = farmId,
+    fillTypeIndex  = fillType.index,
+    fillTypeName   = "wheat",
+    quantity       = 20000,          -- liters
+    lockedPrice    = currentPrice,   -- use getPrice() for current market price
+    deliveryTimeMs = deadline,       -- absolute game time in ms
+})
+```
+
+Getting a reasonable delivery deadline (e.g. 3 in-game days from now):
+
+```lua
+local now = g_currentMission.time
+local threeDaysMs = 3 * 24 * 60 * 60 * 1000
+local deadline = now + threeDaysMs
+```
+
+---
+
+## Recording a Delivery (from GUI or sell hook)
+
+```lua
+-- Call when player delivers crop toward a contract
+local fulfilled = g_MarketDynamics.futuresMarket:recordDelivery(contractId, liters)
+if fulfilled then
+    -- show fulfillment notification
+end
+```
+
+---
+
+## See Also
+
+- [Integration Guide](integration-guide.md) — How to set up `g_MDMHud`
+- [Translation Keys](l10n-keys.md) — L10N strings for UI labels
+- [API Reference](../dev/api-reference.md) — Full method signatures and types

--- a/docs/gui/integration-guide.md
+++ b/docs/gui/integration-guide.md
@@ -1,0 +1,132 @@
+# GUI Integration Guide — LeGrizzly (dev-2)
+
+How to hook your HUD into the MarketDynamics core without touching `src/` files.
+
+---
+
+## The Integration Contract
+
+The core system provides one hook point for GUI:
+
+```lua
+-- In MarketDynamics:draw() — called every frame
+if g_MDMHud then
+    g_MDMHud:draw()
+end
+```
+
+**Your job:** Set `g_MDMHud` to an object with a `draw()` method. The core calls it every frame.
+You never modify files in `src/`. All GUI code lives in `gui/`.
+
+---
+
+## Setting Up g_MDMHud
+
+Set the global after your HUD is initialized and ready to draw:
+
+```lua
+-- In your HUD init (after GUI elements are loaded):
+g_MDMHud = MyHud.new()
+```
+
+Unset it on cleanup:
+
+```lua
+-- In your HUD delete:
+g_MDMHud = nil
+```
+
+The core's `draw()` guard (`if g_MDMHud then`) handles the case where your HUD
+isn't loaded yet or has been cleaned up — no errors, no crashes.
+
+---
+
+## Timing — When Is Data Available?
+
+| Data | Available After |
+|------|----------------|
+| `g_MarketDynamics` exists | `Mission00.load` |
+| Subsystems initialized | `Mission00.loadMission00Finished` |
+| Save data restored | `Mission00.onStartMission` |
+| Prices populated | `MarketEngine:init()` (called in `loadMission00Finished`) |
+
+Initialize your HUD after `loadMission00Finished`. Querying prices or contracts
+before this point will return nil or empty tables.
+
+---
+
+## Reading Data
+
+All data queries go through `g_MarketDynamics` and its subsystems.
+**Never access subsystem internals directly** — use the public methods.
+
+See [Data Queries](data-queries.md) for the full reference. Quick examples:
+
+```lua
+-- Current price for a fill type
+local price = g_MarketDynamics.marketEngine:getPrice(fillTypeIndex)
+
+-- Active world events (for event ticker/banner)
+local events = g_MarketDynamics.worldEvents:getActiveEvents()
+-- returns: { { id, name, intensity, endsAt }, ... }
+
+-- Farm's futures contracts
+local contracts = g_MarketDynamics.futuresMarket:getContractsForFarm(farmId)
+-- returns: { Contract, ... }  (see API Reference for Contract fields)
+```
+
+---
+
+## Guard Pattern
+
+Always guard reads with existence checks — the core may not be active yet
+(e.g., during map loading):
+
+```lua
+function MyHud:draw()
+    if not g_MarketDynamics or not g_MarketDynamics.isActive then return end
+
+    -- safe to query now
+    local events = g_MarketDynamics.worldEvents:getActiveEvents()
+    -- ...
+end
+```
+
+---
+
+## Branch Rules
+
+- **GUI branch:** `dev-2` (LeGrizzly)
+- **Core branch:** `dev-1` (tison)
+- GUI PRs must never modify files in `src/`
+- Core PRs must never modify files in `gui/`
+- Merge conflicts in shared files (e.g. `main.lua`, `modDesc.xml`) — coordinate before merging
+
+---
+
+## File Organization
+
+```
+gui/
+  MyHud.lua              ← main HUD class
+  MyHud.xml              ← layout descriptor (if using FS25 XML GUI)
+  textures/              ← HUD graphics
+```
+
+Add your Lua files to `main.lua` source order. GUI files should be sourced after all
+`src/` files but can be before or after `src/MarketDynamics.lua` — the hook is set
+at runtime, not at source time.
+
+---
+
+## Translation Keys
+
+L10N strings used by core and available for GUI are listed in [Translation Keys](l10n-keys.md).
+
+---
+
+## See Also
+
+- [Data Queries](data-queries.md) — All public read APIs for GUI use
+- [Translation Keys](l10n-keys.md) — Available L10N strings
+- [API Reference](../dev/api-reference.md) — Full method signatures

--- a/docs/gui/l10n-keys.md
+++ b/docs/gui/l10n-keys.md
@@ -1,0 +1,74 @@
+# Translation Keys — L10N Strings
+
+All available localization keys defined in `translations/translation_en.xml`.
+Use these in your GUI XML layouts or Lua via `g_i18n:getText("key")`.
+
+---
+
+## Usage
+
+```lua
+-- In Lua
+local label = g_i18n:getText("mdm_hud_title")  -- "Market Watch"
+
+-- In XML layout
+-- <TextElement text="$l10n_mdm_hud_title" />
+```
+
+---
+
+## Event Names
+
+| Key | English Text |
+|-----|-------------|
+| `mdm_event_drought` | Regional Drought |
+| `mdm_event_bumper_harvest` | Bumper Harvest |
+| `mdm_event_trade_disruption` | Trade Disruption |
+| `mdm_event_geopolitical` | Geopolitical Crisis |
+
+These match the `name` field returned by `worldEvents:getActiveEvents()`.
+You can also just use the `name` field directly from the event summary — it's the same string.
+
+---
+
+## HUD Labels
+
+| Key | English Text |
+|-----|-------------|
+| `mdm_hud_title` | Market Watch |
+| `mdm_hud_active_events` | Active Events |
+| `mdm_hud_no_events` | Markets stable |
+
+---
+
+## Futures UI
+
+| Key | English Text |
+|-----|-------------|
+| `mdm_futures_title` | Futures Market |
+| `mdm_futures_create` | New Contract |
+| `mdm_futures_fulfill` | Fulfilled |
+| `mdm_futures_defaulted` | Defaulted |
+| `mdm_futures_active` | Active |
+| `mdm_futures_delivery_label` | Delivery |
+| `mdm_futures_locked_label` | Locked Price |
+| `mdm_futures_quantity_label` | Quantity (L) |
+
+---
+
+## Adding New Keys
+
+1. Add the entry to `translations/translation_en.xml`
+2. Add matching entries to any other translation files if they exist
+3. Use the `mdm_` prefix for all MarketDynamics keys
+
+```xml
+<text name="mdm_my_new_key" text="My Label" />
+```
+
+---
+
+## See Also
+
+- [Integration Guide](integration-guide.md) — GUI setup
+- [Data Queries](data-queries.md) — What data to display

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,54 @@
+# FS25_MarketDynamics — Documentation
+
+Dynamic crop pricing driven by world events, supply/demand, and intraday volatility.
+Includes a futures contract system for hedging harvest prices.
+
+**Version:** 0.1.0.0 · **Authors:** TheCodingDad (tison) & LeGrizzly
+
+---
+
+## Who Are You?
+
+| You Are | Start Here |
+|---------|-----------|
+| A player/farmer using the mod | [Player Guide →](player-guide/overview.md) |
+| A developer working on core systems | [Architecture →](dev/architecture.md) |
+| LeGrizzly building the GUI | [GUI Integration →](gui/integration-guide.md) |
+| A community contributor | [Dev Overview →](dev/architecture.md) + [Event Authoring →](dev/event-authoring.md) |
+
+---
+
+## Contents
+
+### Player Guide
+- [Overview](player-guide/overview.md) — What this mod does and why
+- [World Events](player-guide/world-events.md) — All 4 events explained
+- [Futures Contracts](player-guide/futures-contracts.md) — Lock in your harvest price
+
+### Developer Docs
+- [Architecture](dev/architecture.md) — System design, module map, lifecycle
+- [API Reference](dev/api-reference.md) — Public methods for every module
+- [Event Authoring](dev/event-authoring.md) — How to create and register new events
+- [Serialization](dev/serialization.md) — Save/load system internals
+- [Lua Compatibility](dev/lua-compat.md) — Lua 5.1 / FS25 gotchas
+
+### GUI Integration (LeGrizzly)
+- [Integration Guide](gui/integration-guide.md) — How to hook your HUD into the core
+- [Data Queries](gui/data-queries.md) — Reading prices, events, and contracts
+- [Translation Keys](gui/l10n-keys.md) — All available L10N strings
+
+---
+
+## Quick Reference
+
+```
+g_MarketDynamics                 Central coordinator (global)
+  ├── marketEngine               Price management & volatility
+  ├── worldEvents                Event registry & scheduling
+  ├── futuresMarket              Contract creation & fulfillment
+  └── serializer                 Save/load to modSettings XML
+```
+
+**Log prefix:** `[MDM]`
+**Save path:** `<savegameDir>/modSettings/FS25_MarketDynamics.xml`
+**Multiplayer:** Not supported (single-player only)

--- a/docs/player-guide/futures-contracts.md
+++ b/docs/player-guide/futures-contracts.md
@@ -1,0 +1,83 @@
+# Player Guide — Futures Contracts
+
+A futures contract lets you lock in a crop price today for a delivery you'll make in the future.
+It's your main tool for protecting yourself against price crashes — and for capitalizing on
+price spikes before your harvest even comes in.
+
+---
+
+## How It Works
+
+1. **You agree to sell** a set quantity of a crop at today's price, with a delivery deadline.
+2. **You grow and deliver** the crop before that deadline.
+3. **At the deadline**, the system checks your delivery:
+   - **Fulfilled** (≥ quantity delivered): You receive the full locked-in payout.
+   - **Defaulted** (< quantity delivered): You receive partial pay for what was delivered,
+     minus a **15% penalty** on the unfulfilled portion.
+
+The locked price doesn't change — even if market prices crash or spike after you sign.
+
+---
+
+## Why Use Futures?
+
+### Scenario A — Price Protection
+
+You see a **Geopolitical Crisis** spike canola prices to +45%. You don't have the crop yet,
+but you can lock in that elevated price right now. Even if the event ends and prices fall
+before your harvest, you still get paid the locked rate.
+
+### Scenario B — Hedging Against Bumper Harvest
+
+You're storing 50,000L of wheat. A **Bumper Harvest** looks likely — prices are about to
+fall 20%. Lock in the current price before the event fires, then deliver after.
+
+### Scenario C — Planned Selling
+
+You know you'll have 30,000L of barley ready in 3 in-game days. Lock in today's price and
+remove the uncertainty entirely. No need to watch the market.
+
+---
+
+## The Default Penalty
+
+If you can't deliver the full contracted quantity by the deadline:
+
+- You receive the locked price for **everything you did deliver**.
+- You pay a **15% penalty** on the value of the **undelivered portion**.
+
+**Example:**
+
+| Contract | 10,000L wheat @ $2.50/L |
+|----------|------------------------|
+| Delivered | 7,000L |
+| Shortfall | 3,000L |
+| Partial payout | 7,000 × $2.50 = **$17,500** |
+| Penalty | 3,000 × $2.50 × 15% = **-$1,125** |
+| **Net received** | **$16,375** |
+
+Don't commit to more than you can grow.
+
+---
+
+## Strategy Tips
+
+- **Don't over-commit.** Only contract quantities you're confident you can deliver.
+  If a drought spikes prices, it's tempting to lock in a huge contract — but if your
+  harvest underperforms, the penalty hurts.
+
+- **Shorter deadlines = less risk.** The closer the deadline to when your crops are
+  actually ready, the less can go wrong.
+
+- **Futures + events = powerful combo.** Use futures to lock in event-driven price spikes.
+  That's what they're designed for.
+
+- **Watch your silos.** Delivery counts grain already in storage. If you have crop ready,
+  a short-deadline contract is almost risk-free.
+
+---
+
+## See Also
+
+- [Overview](overview.md) — How the whole mod works
+- [World Events](world-events.md) — Events that create futures opportunities

--- a/docs/player-guide/overview.md
+++ b/docs/player-guide/overview.md
@@ -1,0 +1,76 @@
+# Player Guide — Overview
+
+## What Does This Mod Do?
+
+FS25_MarketDynamics replaces the static crop pricing system with a living economy.
+Prices move throughout the day, respond to world events, and you can lock in a future
+price before your harvest even comes in.
+
+---
+
+## The Problem With Vanilla Pricing
+
+In vanilla Farming Simulator 25, crop prices fluctuate gently on a predictable curve.
+There are no surprises. Sell at the right time, get the best price — every season,
+every year, same game.
+
+This mod changes that.
+
+---
+
+## What Changes
+
+### 1. Prices Move Dynamically
+
+Crop prices shift throughout the game day:
+
+- **Intraday volatility** — Small fluctuations every in-game minute (±2%)
+- **Daily drift** — A broader trend shift every in-game day (±5%)
+
+You'll see prices tick up and down as you play. Selling the same grain in the morning
+versus the afternoon can make a real difference.
+
+### 2. World Events Shake Up the Market
+
+Random world events fire periodically and spike (or crash) prices significantly.
+Some events affect a single crop category. Others hit the whole market.
+
+There are 4 event types:
+
+| Event | Effect | Crops Affected |
+|-------|--------|---------------|
+| Drought | Prices spike +10–35% | Grains |
+| Bumper Harvest | Prices crash -8–25% | Grains |
+| Trade Disruption | Mixed volatility +5–25% | Random selection |
+| Geopolitical Crisis | Prices surge +15–55% | Staples & energy crops |
+
+Events are temporary. When they end, prices return to their pre-event baseline.
+
+### 3. Futures Contracts — Lock In Your Price
+
+A futures contract lets you agree today to sell a set quantity of crop at a set
+price, with delivery due at a future date.
+
+**Why use them?**
+
+If you think a drought will spike wheat prices in the next season, you can lock
+in that elevated price now — before you've even grown the wheat. If the price
+drops later, you still get paid the rate you locked in.
+
+**The catch:**
+
+If you can't deliver the full quantity by the due date, you'll be penalized 15%
+on the shortfall. Don't over-commit.
+
+---
+
+## Multiplayer
+
+This mod is **single-player only**. It will not function correctly in multiplayer sessions.
+
+---
+
+## See Also
+
+- [World Events Reference](world-events.md)
+- [Futures Contracts Guide](futures-contracts.md)

--- a/docs/player-guide/world-events.md
+++ b/docs/player-guide/world-events.md
@@ -1,0 +1,105 @@
+# Player Guide — World Events
+
+World events are random, temporary shocks that move crop prices significantly.
+They fire automatically — you don't trigger them. You just have to react.
+
+---
+
+## How Events Work
+
+Every 5 in-game minutes, the system rolls the dice for each event type. If an event
+fires, it applies a price multiplier to specific crops for a set duration. When the
+event expires, those multipliers are removed and prices return to baseline.
+
+Only one event of each type can be active at a time. Each event has a minimum cooldown
+before it can fire again.
+
+---
+
+## Event Reference
+
+### Drought
+
+> A region-wide drought cuts crop yields and drives up grain prices.
+
+| Property | Value |
+|----------|-------|
+| Price change | +10% to +35% |
+| Affected crops | Wheat, barley, canola, corn, sunflower |
+| Duration | ~15 in-game minutes |
+| Fire chance | 8% per check |
+| Cooldown | 30 in-game minutes |
+
+**Strategy:** If you have grain in storage, a drought is a great time to sell.
+If you have a futures contract for grain delivery, this event validates that hedge.
+
+---
+
+### Bumper Harvest
+
+> An exceptionally large regional harvest floods the market, pushing grain prices down.
+
+| Property | Value |
+|----------|-------|
+| Price change | -8% to -25% |
+| Affected crops | Wheat, barley, corn, oat, sorghum |
+| Duration | ~12 in-game minutes |
+| Fire chance | 10% per check |
+| Cooldown | 25 in-game minutes |
+
+**Strategy:** This is the most common negative event. If you're holding grain and a
+bumper harvest fires, consider waiting it out. If you locked in a futures contract
+before this event, you're protected from the price drop.
+
+---
+
+### Trade Disruption
+
+> Supply chain chaos creates unpredictable price swings across the commodity market.
+
+| Property | Value |
+|----------|-------|
+| Price change | +5% to +25% |
+| Affected crops | Random 50% selection from: wheat, barley, canola, corn, sunflower, soybean, oat |
+| Duration | ~8 in-game minutes |
+| Fire chance | 6% per check |
+| Cooldown | 40 in-game minutes |
+
+**Strategy:** This is the wildcard event. You won't know which crops are affected
+until it fires. Diversified inventories benefit most here — something in your silos
+is almost certain to spike. Duration is short, so act quickly.
+
+---
+
+### Geopolitical Crisis
+
+> International tensions disrupt food and energy commodity markets worldwide.
+
+| Property | Value |
+|----------|-------|
+| Price change (staples) | +15% to +45% — Wheat, barley |
+| Price change (energy crops) | +20% to +55% — Canola, sunflower |
+| Duration | ~20 in-game minutes |
+| Fire chance | 4% per check |
+| Cooldown | 60 in-game minutes |
+
+**Strategy:** This is the rarest and most powerful event. Canola and sunflower can
+see enormous price surges. The long duration (20 min) gives you more time to react
+and sell. Because it's rare and the cooldown is long, don't expect it to save you
+regularly — but when it fires, it's a major opportunity.
+
+---
+
+## Seeing Active Events
+
+The HUD (top of screen, provided by LeGrizzly's GUI) shows currently active events
+and which crops are affected. If no events are active, the panel will read "No active events."
+
+---
+
+## Tips
+
+- **Bumper Harvest is the most common** (10% chance). Expect it regularly.
+- **Geopolitical Crisis is the rarest** (4% chance, 60-min cooldown). Don't plan around it.
+- **Events stack with intraday volatility** — a drought during a natural price peak is a great sell window.
+- **Futures contracts are your insurance** against negative events like Bumper Harvest.


### PR DESCRIPTION
**What this adds**

Completes the `docs/` folder with 12 files across three sections. The index already existed as a stub with broken links — all linked pages are now written.

**Player Guide** (`docs/player-guide/`)
- `overview.md` — what the mod does, how pricing/events/futures work at a high level
- `world-events.md` — all 4 events with stats, strategy tips, and a reference table
- `futures-contracts.md` — how contracts work, the default penalty with a worked example, strategy tips

**Developer Docs** (`docs/dev/`)
- `architecture.md` — module map, full load order, game hook table, lifecycle sequence, price model explanation, event scheduling internals, save format schema
- `api-reference.md` — every public method for all 5 modules (MarketDynamics, MarketEngine, WorldEventSystem, FuturesMarket, MarketSerializer, MDMLog) with param and return types
- `event-authoring.md` — minimal event template, all registration fields explained, intensity mapping patterns, balance reference table, testing workflow
- `serialization.md` — what is/isn't saved and why, full XML schema, save/load flow with code, guidance for adding new fields
- `lua-compat.md` — Lua 5.1 restrictions, FS25 API gotchas, performance rules, quick reference table

**GUI Integration** (`docs/gui/`) — written for LeGrizzly / dev-2
- `integration-guide.md` — how to set `g_MDMHud`, timing rules, branch boundaries, file organization
- `data-queries.md` — all public read APIs for prices, active events, and contracts with copy-paste code examples including contract creation and delivery recording
- `l10n-keys.md` — all 13 translation keys from `translation_en.xml` with usage examples for both Lua and XML layouts

---

**Notes**
- All docs are grounded in the actual source — no invented APIs
- Cross-links between docs are consistent and resolve correctly
- No changes to any `src/` files