### PR TITLE
feat: Phase 2 - Engine Persistence & World Events

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(grep:*)",
       "WebFetch(domain:github-production-user-asset-6210df.s3.amazonaws.com)",
       "Bash(gh api:*)",
-      "Bash(gh repo:*)"
+      "Bash(gh repo:*)",
+      "Bash(for repo:*)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# FS25_MarketDynamics
+
+> [!TIP]
+> Want to join the conversation? Or check what phase is being worked on?
+> Click below to dive in!
+> [Dev Log & Progress Tracker](https://github.com/TheCodingDad-TisonK/TheCodingDad-TisonK/issues/4)
+
+**Real-world inspired dynamic crop pricing for Farming Simulator 25.**
+
+Prices no longer sit static. A drought in Europe, a bumper harvest in the Americas, a geopolitical crisis — they all move markets. Track live prices, react to global events, and lock in your harvest via futures contracts like a real commodity trader.
+
+---
+
+## Features
+
+### Dynamic Pricing Engine
+- Per-fillType price state with base + live modifier stack
+- Intraday micro-fluctuations (every in-game minute)
+- Daily trend shifts with mean-reversion toward base price
+- All effects stack and expire cleanly
+
+### World Event System
+| Event | Price Impact | Duration |
+|-------|-------------|----------|
+| Regional Drought | Grain +10–35% | ~15 min |
+| Bumper Harvest | Grain -8–25% | ~12 min |
+| Trade Disruption | Mixed crops +5–25% | ~8 min |
+| Geopolitical Crisis | Staples +15–45%, Energy crops +20–55% | ~20 min |
+
+Events fire probabilistically on a timer with per-type cooldowns so markets feel alive, not random chaos.
+
+### Futures Contracts
+- Lock in a price months in advance for any crop
+- Commit to a quantity and delivery date
+- Fulfill early → full locked payout
+- Default → partial payout minus 15% penalty on unfulfilled portion
+
+### Market HUD *(in development — LeGrizzly)*
+- Corner price ticker for key crops
+- Active event notification banners
+- Full market screen with price history
+
+---
+
+## Installation
+
+1. Download `FS25_MarketDynamics.zip`
+2. Place in `Documents/My Games/FarmingSimulator2025/mods/`
+3. Enable in the mod manager
+
+---
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch structure, coding standards, and build instructions.
+
+**Authors:**
+- **TisonK (TheCodingDad)** — core systems (engine, events, futures, serializer)
+- **LeGrizzly** — GUI systems (market screen, HUD, futures dialog)
+
+---
+
+## License
+
+[CC BY-NC-ND 4.0](LICENSE) — Attribution, Non-Commercial, No Derivatives.

--- a/main.lua
+++ b/main.lua
@@ -1,14 +1,104 @@
-# Build output
-*.zip
+-- FS25_MarketDynamics / main.lua
+-- Entry point. Loads all modules in dependency order, then hooks into the game lifecycle.
+-- Log prefix: [MDM]  |  Global: g_MarketDynamics
+--
+-- Authors: TheCodingDad (tison) — core systems
+--          LeGrizzly             — GUI systems
 
-# OS
-.DS_Store
-Thumbs.db
+local modDirectory = g_currentModDirectory
+local modName      = g_currentModName
 
-# Editor
-.vscode/
-*.swp
-*~
+-- ---------------------------------------------------------------------------
+-- Source all modules
+-- (Order mirrors modDesc.xml extraSourceFiles — do not reorder)
+-- ---------------------------------------------------------------------------
 
-# Logs
-*.log
+-- Utilities
+source(modDirectory .. "src/Logger.lua")
+
+-- Core systems
+source(modDirectory .. "src/MarketEngine.lua")
+source(modDirectory .. "src/WorldEventSystem.lua")
+source(modDirectory .. "src/FuturesMarket.lua")
+source(modDirectory .. "src/MarketSerializer.lua")
+
+-- Price hook (installed at source-time, dormant until isActive=true)
+source(modDirectory .. "src/PriceHook.lua")
+
+-- Admin/debug console commands
+source(modDirectory .. "src/AdminCommands.lua")
+
+-- Integrations (optional, loaded if target mod is detected at runtime)
+source(modDirectory .. "src/BCIntegration.lua")
+source(modDirectory .. "src/UPIntegration.lua")
+
+-- Debug HUD (TEMP: remove when LeGrizzly's GUI lands)
+source(modDirectory .. "src/DebugHUD.lua")
+source(modDirectory .. "src/gui/SettingsUI.lua")
+
+-- Events
+source(modDirectory .. "src/events/DroughtEvent.lua")
+source(modDirectory .. "src/events/BumperHarvestEvent.lua")
+source(modDirectory .. "src/events/TradeDisruptionEvent.lua")
+source(modDirectory .. "src/events/GeopoliticalEvent.lua")
+
+-- Coordinator (depends on everything above)
+source(modDirectory .. "src/MarketDynamics.lua")
+
+-- ---------------------------------------------------------------------------
+-- Lifecycle hooks
+-- ---------------------------------------------------------------------------
+
+local mdm = nil  -- will hold the MarketDynamics instance
+
+local function onLoad(mission)
+    mdm = MarketDynamics.new(modDirectory, modName)
+    getfenv(0)["g_MarketDynamics"] = mdm
+end
+
+local function onLoadFinished(mission)
+    if mdm then
+        mdm:onMissionLoaded(mission)
+    end
+end
+
+local function onStartMission(mission)
+    if mdm then
+        mdm:onStartMission(mission)
+    end
+end
+
+local function onUpdate(mission, dt)
+    if mdm then
+        mdm:update(dt)
+    end
+end
+
+local function onDraw(mission)
+    if mdm then
+        mdm:draw()
+    end
+end
+
+local function onSave(mission, xmlFile)
+    if mdm then
+        mdm:save(xmlFile)
+    end
+end
+
+local function onDelete(mission)
+    if mdm then
+        mdm:delete()
+        mdm = nil
+        getfenv(0)["g_MarketDynamics"] = nil
+    end
+end
+
+-- Attach to game hooks
+Mission00.load                  = Utils.prependedFunction(Mission00.load,                  onLoad)
+Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished,  onLoadFinished)
+Mission00.onStartMission        = Utils.appendedFunction(Mission00.onStartMission,         onStartMission)
+FSBaseMission.update            = Utils.appendedFunction(FSBaseMission.update,             onUpdate)
+FSBaseMission.draw              = Utils.appendedFunction(FSBaseMission.draw,               onDraw)
+FSCareerMissionInfo.saveToXMLFile = Utils.appendedFunction(FSCareerMissionInfo.saveToXMLFile, onSave)
+FSBaseMission.delete            = Utils.appendedFunction(FSBaseMission.delete,             onDelete)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,65 +1,24 @@
-# FS25_MarketDynamics
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<modDesc descVersion="106">
+    <author>TheCodingDad (tison) &amp; LeGrizzly</author>
+    <version>0.1.0.0</version>
+    <title>
+        <en>Market Dynamics</en>
+    </title>
+    <description>
+        <en>Real-world inspired dynamic crop pricing. Prices fluctuate daily and intraday based on global events, weather, and supply/demand. Includes a futures contract system — lock in prices months in advance and hedge your harvest like a real commodity trader.</en>
+    </description>
+    <iconFilename>icon.dds</iconFilename>
+    <multiplayer supported="false" />
 
-> [!TIP]
-> Want to join the conversation? Or check what phase is being worked on?
-> Click below to dive in!
-> [Dev Log & Progress Tracker](https://github.com/TheCodingDad-TisonK/TheCodingDad-TisonK/issues/4)
+    <extraSourceFiles>
+        <sourceFile filename="main.lua" />
+    </extraSourceFiles>
 
-**Real-world inspired dynamic crop pricing for Farming Simulator 25.**
+    <l10n filenamePrefix="translations/translation" />
 
-Prices no longer sit static. A drought in Europe, a bumper harvest in the Americas, a geopolitical crisis — they all move markets. Track live prices, react to global events, and lock in your harvest via futures contracts like a real commodity trader.
-
----
-
-## Features
-
-### Dynamic Pricing Engine
-- Per-fillType price state with base + live modifier stack
-- Intraday micro-fluctuations (every in-game minute)
-- Daily trend shifts with mean-reversion toward base price
-- All effects stack and expire cleanly
-
-### World Event System
-| Event | Price Impact | Duration |
-|-------|-------------|----------|
-| Regional Drought | Grain +10–35% | ~15 min |
-| Bumper Harvest | Grain -8–25% | ~12 min |
-| Trade Disruption | Mixed crops +5–25% | ~8 min |
-| Geopolitical Crisis | Staples +15–45%, Energy crops +20–55% | ~20 min |
-
-Events fire probabilistically on a timer with per-type cooldowns so markets feel alive, not random chaos.
-
-### Futures Contracts
-- Lock in a price months in advance for any crop
-- Commit to a quantity and delivery date
-- Fulfill early → full locked payout
-- Default → partial payout minus 15% penalty on unfulfilled portion
-
-### Market HUD *(in development — LeGrizzly)*
-- Corner price ticker for key crops
-- Active event notification banners
-- Full market screen with price history
-
----
-
-## Installation
-
-1. Download `FS25_MarketDynamics.zip`
-2. Place in `Documents/My Games/FarmingSimulator2025/mods/`
-3. Enable in the mod manager
-
----
-
-## Development
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branch structure, coding standards, and build instructions.
-
-**Authors:**
-- **TisonK (TheCodingDad)** — core systems (engine, events, futures, serializer)
-- **LeGrizzly** — GUI systems (market screen, HUD, futures dialog)
-
----
-
-## License
-
-[CC BY-NC-ND 4.0](LICENSE) — Attribution, Non-Commercial, No Derivatives.
+    <dependencies>
+        <dependency optional="true">FS25_BetterContracts</dependency>
+        <dependency optional="true">FS25_UsedPlus</dependency>
+    </dependencies>
+</modDesc>

--- a/src/MarketEngine.lua
+++ b/src/MarketEngine.lua
@@ -6,7 +6,7 @@
 -- Price model per fillType:
 --   current = base * volatilityFactor * product(eventModifiers)
 --
---   base             — vanilla sell price, snapshotted at init
+--   base             — vanilla sell price, refreshed daily to track seasons
 --   volatilityFactor — running intraday + daily drift, clamped to [0.50, 2.00]
 --   modifiers        — event modifier stack: { id, fillTypeIndex, factor }
 --                      added by WorldEvent.onFire, removed by WorldEvent.onExpire
@@ -16,6 +16,7 @@
 -- Public API (called externally):
 --   init()                                 — snapshot base prices from economy
 --   update(dt)                             — advance intraday/daily timers
+--   refreshBasePrices()                    — sync base prices with vanilla seasonal curves
 --   addModifier(modifier)                  — push an event modifier onto the stack
 --   removeModifierById(fillTypeIndex, id)  — pop a modifier by id
 --   getPrice(fillTypeIndex)                — current effective price (or nil)
@@ -32,9 +33,10 @@ local INTRADAY_INTERVAL_MS = 60 * 1000       -- every in-game minute
 local DAILY_INTERVAL_MS    = 24 * 60 * 1000  -- every in-game day
 
 -- Volatility parameters
-local INTRADAY_MAGNITUDE   = 0.02   -- ±2% per intraday tick
-local DAILY_MAGNITUDE      = 0.05   -- ±5% per daily shift
-local MEAN_REVERSION_RATE  = 0.15   -- fraction of (1.0 - volatilityFactor) applied per day
+local INTRADAY_MAGNITUDE   = 0.002  -- ±0.2% per intraday tick (dampened)
+local DAILY_MAGNITUDE      = 0.03   -- ±3% per daily shift
+local INTRADAY_REVERSION   = 0.005  -- 0.5% pull toward 1.0 per minute
+local DAILY_REVERSION      = 0.15   -- 15% pull toward 1.0 per day
 local VOLATILITY_MIN       = 0.50   -- hard floor: never less than 50% of base
 local VOLATILITY_MAX       = 2.00   -- hard ceiling: never more than 200% of base
 
@@ -59,40 +61,47 @@ function MarketEngine.new()
 end
 
 -- Called once after mission load — snapshots base prices from the vanilla economy.
--- Safe to call while g_MarketDynamics.isActive is still false: PriceHook's guard
--- lets vanilla results pass through until isActive = true, so origGetPrice returns
--- unmodified prices here.
 function MarketEngine:init()
     if not g_fillTypeManager then
         MDMLog.warn("MarketEngine:init() — g_fillTypeManager not available")
         return
     end
-    if not g_currentMission or not g_currentMission.economyManager then
-        MDMLog.warn("MarketEngine:init() — economyManager not available")
-        return
-    end
+    self:refreshBasePrices(true)
+    MDMLog.info("MarketEngine:init() — initialized fill type prices")
+end
+
+-- Sync base prices with current vanilla seasonal curves.
+-- If isInitial is true, it populates the table; otherwise it just updates 'base'.
+function MarketEngine:refreshBasePrices(isInitial)
+    if not g_currentMission or not g_currentMission.economyManager then return end
 
     local fillTypes = g_fillTypeManager:getFillTypes()
     local count     = 0
 
     for _, fillType in ipairs(fillTypes) do
-        -- Skip UNKNOWN (index 1) and any invalid entries
         if fillType and fillType.index and fillType.index > 1 then
             local basePrice = MDMGetVanillaPrice(g_currentMission.economyManager, fillType.index)
             if basePrice and basePrice > 0 then
-                self.prices[fillType.index] = {
-                    base             = basePrice,
-                    volatilityFactor = 1.0,
-                    modifiers        = {},
-                    current          = basePrice,
-                    history          = {},   -- { price, time } newest-last; max HISTORY_MAX_ENTRIES
-                }
+                if isInitial and not self.prices[fillType.index] then
+                    self.prices[fillType.index] = {
+                        base             = basePrice,
+                        volatilityFactor = 1.0,
+                        modifiers        = {},
+                        current          = basePrice,
+                        history          = {},
+                    }
+                elseif self.prices[fillType.index] then
+                    self.prices[fillType.index].base = basePrice
+                    self:_recalculate(fillType.index)
+                end
                 count = count + 1
             end
         end
     end
 
-    MDMLog.info("MarketEngine:init() — snapshotted " .. count .. " fill type prices")
+    if isInitial then
+        MDMLog.info("MarketEngine: snapshotted " .. count .. " base prices")
+    end
 end
 
 -- Advance timers and fire intraday/daily volatility ticks.
@@ -109,12 +118,11 @@ function MarketEngine:update(dt)
     if self.dailyTimer >= DAILY_INTERVAL_MS then
         self.dailyTimer = 0
         self:_applyDailyShift()
+        self:refreshBasePrices(false) -- Sync with seasonal changes daily
     end
 end
 
 -- Push an event modifier onto a fillType's modifier stack.
--- modifier = { id, fillTypeIndex, factor }
--- Expiry is handled by WorldEventSystem calling onExpire → removeModifierById.
 function MarketEngine:addModifier(modifier)
     local entry = self.prices[modifier.fillTypeIndex]
     if not entry then return end
@@ -124,8 +132,6 @@ function MarketEngine:addModifier(modifier)
 end
 
 -- Remove a modifier by id from a fillType's modifier stack.
--- Called from world event onExpire callbacks.
--- Safe to call for an id that doesn't exist (no-op).
 function MarketEngine:removeModifierById(fillTypeIndex, id)
     local entry = self.prices[fillTypeIndex]
     if not entry then return end
@@ -139,7 +145,6 @@ function MarketEngine:removeModifierById(fillTypeIndex, id)
 end
 
 -- Returns the current effective price for a fillType, or nil if not tracked.
--- Called by PriceHook at point of sale.
 function MarketEngine:getPrice(fillTypeIndex)
     local entry = self.prices[fillTypeIndex]
     if entry then return entry.current end
@@ -147,7 +152,6 @@ function MarketEngine:getPrice(fillTypeIndex)
 end
 
 -- Returns price history array for GUI display.
--- Format: { { price, time }, ... } newest-last, up to HISTORY_MAX_ENTRIES entries.
 function MarketEngine:getPriceHistory(fillTypeIndex)
     local entry = self.prices[fillTypeIndex]
     if entry then return entry.history end
@@ -155,7 +159,6 @@ function MarketEngine:getPriceHistory(fillTypeIndex)
 end
 
 -- Returns the percentage change of the current price relative to the base price.
--- Positive = above base, negative = below base. Used by HUD trend indicators.
 function MarketEngine:getPriceChangePercent(fillTypeIndex)
     local entry = self.prices[fillTypeIndex]
     if not entry or entry.base <= 0 then return 0 end
@@ -166,30 +169,39 @@ end
 -- Private
 -- ---------------------------------------------------------------------------
 
--- Small random walk on volatilityFactor — ±2% per in-game minute (scaled by volatilityScale).
--- Recalculates current price for every tracked fillType.
+-- Small random walk + mean reversion toward 1.0 (dampened).
 function MarketEngine:_applyIntradayVolatility()
-    local magnitude = INTRADAY_MAGNITUDE * (self.volatilityScale or 1.0)
+    local scale     = self.volatilityScale or 1.0
+    local magnitude = INTRADAY_MAGNITUDE * scale
+    local reversion = INTRADAY_REVERSION
+
     for fillTypeIndex, entry in pairs(self.prices) do
-        local delta    = (math.random() * 2 - 1) * magnitude
-        local newFactor = entry.volatilityFactor * (1 + delta)
+        local vf = entry.volatilityFactor
+        -- Pull toward 1.0 (mean reversion)
+        local revDelta  = (1.0 - vf) * reversion
+        -- Random jitter
+        local randDelta = (math.random() * 2 - 1) * magnitude
+        
+        local newFactor = vf + revDelta + randDelta
         entry.volatilityFactor = math.max(VOLATILITY_MIN, math.min(VOLATILITY_MAX, newFactor))
         self:_recalculate(fillTypeIndex)
     end
 end
 
--- Daily shift: mean-reversion toward 1.0 + random trend ±5% (scaled by volatilityScale).
--- Records a price history snapshot after recalculation.
+-- Daily shift: mean-reversion toward 1.0 + random trend (±3% scaled).
 function MarketEngine:_applyDailyShift()
     local now            = g_currentMission and g_currentMission.time or 0
-    local dailyMagnitude = DAILY_MAGNITUDE * (self.volatilityScale or 1.0)
+    local scale          = self.volatilityScale or 1.0
+    local dailyMagnitude = DAILY_MAGNITUDE * scale
+    local dailyReversion = DAILY_REVERSION
 
     for fillTypeIndex, entry in pairs(self.prices) do
         local vf = entry.volatilityFactor
-        -- Mean-reversion: pull vf back toward neutral (1.0) by MEAN_REVERSION_RATE fraction
-        local reversion = (1.0 - vf) * MEAN_REVERSION_RATE
-        -- Random daily trend
+        -- Stronger daily pull toward equilibrium
+        local reversion = (1.0 - vf) * dailyReversion
+        -- Daily market trend
         local trend     = (math.random() * 2 - 1) * dailyMagnitude
+        
         local newFactor = vf + reversion + trend
         entry.volatilityFactor = math.max(VOLATILITY_MIN, math.min(VOLATILITY_MAX, newFactor))
         self:_recalculate(fillTypeIndex)

--- a/src/MarketSerializer.lua
+++ b/src/MarketSerializer.lua
@@ -3,15 +3,14 @@
 --
 -- Save path: <savegameDirectory>/modSettings/FS25_MarketDynamics.xml
 --
--- What is persisted:
---   futures contracts  — all fields needed to reconstruct active/settled contracts
---   event cooldowns    — lastFiredAt per event, so cooldowns survive reload
---   general settings   — pricesEnabled, debugMode
---   volatility scale   — stored on MarketEngine but serialized here
---   integration flags  — BC mode and UP mode (delegated to each integration module)
---
--- Versioning: a #version attribute is written. Currently "1".
--- Future schema changes should increment this and add a migration path in load().
+-- What is persisted (v2):
+--   futures contracts  — active/settled contracts
+--   event cooldowns    — lastFiredAt per event
+--   active events      — currently running events (restored via loadActiveEvent)
+--   market prices      — volatilityFactor per fillType
+--   price history      — daily history samples per fillType
+--   general settings   — pricesEnabled, debugMode, volatilityScale
+--   integration flags  — BC mode and UP mode
 --
 -- Author: tison (dev-1)
 
@@ -26,7 +25,6 @@ function MarketSerializer.new()
 end
 
 -- Persist current market state.
--- coordinator = the MarketDynamics instance (g_MarketDynamics).
 function MarketSerializer:save(coordinator)
     local savegameDir = g_currentMission.missionInfo.savegameDirectory
     if savegameDir == nil or savegameDir == "" then
@@ -42,8 +40,8 @@ function MarketSerializer:save(coordinator)
         return
     end
 
-    -- Schema version stamp — increment if the format ever changes
-    setXMLString(xmlFile, "marketDynamics#version", "1")
+    -- Schema version stamp
+    setXMLString(xmlFile, "marketDynamics#version", "2")
 
     -- ── Futures contracts ────────────────────────────────────────────────
     local contracts = coordinator.futuresMarket and coordinator.futuresMarket.contracts or {}
@@ -62,14 +60,42 @@ function MarketSerializer:save(coordinator)
         i = i + 1
     end
 
-    -- ── World event cooldowns (lastFiredAt per event) ────────────────────
+    -- ── Market Engine (Prices & History) ────────────────────────────────
+    if coordinator.marketEngine then
+        local k = 0
+        for index, entry in pairs(coordinator.marketEngine.prices) do
+            local base = "marketDynamics.prices.price(" .. k .. ")"
+            setXMLInt  (xmlFile, base .. "#index",  index)
+            setXMLFloat(xmlFile, base .. "#factor", entry.volatilityFactor)
+            
+            for m, hist in ipairs(entry.history) do
+                local hBase = base .. ".history(" .. (m-1) .. ")"
+                setXMLFloat(xmlFile, hBase .. "#price", hist.price)
+                setXMLFloat(xmlFile, hBase .. "#time",  hist.time)
+            end
+            k = k + 1
+        end
+    end
+
+    -- ── World Events (Cooldowns & Active) ───────────────────────────────
     if coordinator.worldEvents then
+        -- Cooldowns
         local j = 0
         for id, event in pairs(coordinator.worldEvents.registry) do
             local base = "marketDynamics.events.event(" .. j .. ")"
             setXMLString(xmlFile, base .. "#id",          id)
             setXMLFloat (xmlFile, base .. "#lastFiredAt", event.lastFiredAt)
             j = j + 1
+        end
+
+        -- Active events
+        local a = 0
+        for id, active in pairs(coordinator.worldEvents.active) do
+            local base = "marketDynamics.activeEvents.event(" .. a .. ")"
+            setXMLString(xmlFile, base .. "#id",        id)
+            setXMLFloat (xmlFile, base .. "#endsAt",    active.endsAt)
+            setXMLFloat (xmlFile, base .. "#intensity", active.intensity)
+            a = a + 1
         end
     end
 
@@ -80,13 +106,12 @@ function MarketSerializer:save(coordinator)
         setXMLBool(xmlFile, "marketDynamics.settings#debugMode",     s.debugMode     == true)
     end
 
-    -- ── Volatility scale (lives on MarketEngine but belongs in settings) ─
     if coordinator.marketEngine then
         setXMLFloat(xmlFile, "marketDynamics.settings#volatilityScale",
             coordinator.marketEngine.volatilityScale or 1.0)
     end
 
-    -- ── Integration flags (delegated to each module) ─────────────────────
+    -- ── Integration flags ────────────────────────────────────────────────
     BCIntegration.save(xmlFile, "marketDynamics.bcIntegration")
     UPIntegration.save(xmlFile, "marketDynamics.upIntegration")
 
@@ -95,9 +120,7 @@ function MarketSerializer:save(coordinator)
     MDMLog.info("MarketSerializer: saved to " .. path)
 end
 
--- Load and restore market state from the savegame XML file.
--- No-op (fresh start) if the file does not exist.
--- coordinator = the MarketDynamics instance (g_MarketDynamics).
+-- Load and restore market state.
 function MarketSerializer:load(coordinator)
     local savegameDir = g_currentMission.missionInfo.savegameDirectory
     if savegameDir == nil or savegameDir == "" then
@@ -112,6 +135,8 @@ function MarketSerializer:load(coordinator)
         MDMLog.info("MarketSerializer: no save file found — starting fresh")
         return
     end
+
+    local version = tonumber(getXMLString(xmlFile, "marketDynamics#version") or "1")
 
     -- ── Restore futures contracts ─────────────────────────────────────────
     local i = 0
@@ -134,12 +159,41 @@ function MarketSerializer:load(coordinator)
 
         if coordinator.futuresMarket then
             coordinator.futuresMarket.contracts[id] = contract
-            -- Keep nextId ahead of the highest restored id so new contracts don't collide
             if id >= coordinator.futuresMarket.nextId then
                 coordinator.futuresMarket.nextId = id + 1
             end
         end
         i = i + 1
+    end
+
+    -- ── Restore Market Engine (Prices & History) ──────────────────────────
+    if coordinator.marketEngine and version >= 2 then
+        local k = 0
+        while true do
+            local base  = "marketDynamics.prices.price(" .. k .. ")"
+            local index = getXMLInt(xmlFile, base .. "#index")
+            if not index then break end
+
+            local entry = coordinator.marketEngine.prices[index]
+            if entry then
+                entry.volatilityFactor = getXMLFloat(xmlFile, base .. "#factor") or 1.0
+                
+                -- Restore history
+                entry.history = {}
+                local m = 0
+                while true do
+                    local hBase = base .. ".history(" .. m .. ")"
+                    local p     = getXMLFloat(xmlFile, hBase .. "#price")
+                    if not p then break end
+                    table.insert(entry.history, { price = p, time = getXMLFloat(xmlFile, hBase .. "#time") })
+                    m = m + 1
+                end
+                
+                -- Recalculate 'current' (base price was snapshotted in init())
+                coordinator.marketEngine:_recalculate(index)
+            end
+            k = k + 1
+        end
     end
 
     -- ── Restore event cooldowns ───────────────────────────────────────────
@@ -156,6 +210,21 @@ function MarketSerializer:load(coordinator)
         j = j + 1
     end
 
+    -- ── Restore active events (v2+) ──────────────────────────────────────
+    if coordinator.worldEvents and version >= 2 then
+        local a = 0
+        while true do
+            local base = "marketDynamics.activeEvents.event(" .. a .. ")"
+            local evId = getXMLString(xmlFile, base .. "#id")
+            if not evId then break end
+
+            local endsAt    = getXMLFloat(xmlFile, base .. "#endsAt")
+            local intensity = getXMLFloat(xmlFile, base .. "#intensity")
+            coordinator.worldEvents:loadActiveEvent(evId, endsAt, intensity)
+            a = a + 1
+        end
+    end
+
     -- ── Restore general settings ──────────────────────────────────────────
     if coordinator.settings then
         local pricesEnabled = getXMLBool(xmlFile, "marketDynamics.settings#pricesEnabled")
@@ -166,11 +235,10 @@ function MarketSerializer:load(coordinator)
         local debugMode = getXMLBool(xmlFile, "marketDynamics.settings#debugMode")
         if debugMode ~= nil then
             coordinator.settings.debugMode = debugMode
-            MDMLog.debugEnabled = debugMode  -- keep Logger in sync immediately
+            MDMLog.debugEnabled = debugMode
         end
     end
 
-    -- ── Restore volatility scale ──────────────────────────────────────────
     if coordinator.marketEngine then
         local vScale = getXMLFloat(xmlFile, "marketDynamics.settings#volatilityScale")
         if vScale and vScale > 0 then
@@ -178,10 +246,10 @@ function MarketSerializer:load(coordinator)
         end
     end
 
-    -- ── Integration flags (delegated to each module) ──────────────────────
+    -- ── Integration flags ─────────────────────────────────────────────────
     BCIntegration.load(xmlFile, "marketDynamics.bcIntegration")
     UPIntegration.load(xmlFile, "marketDynamics.upIntegration")
 
     delete(xmlFile)
-    MDMLog.info("MarketSerializer: loaded " .. i .. " contracts, " .. j .. " event states")
+    MDMLog.info("MarketSerializer: restored version " .. version)
 end

--- a/src/WorldEventSystem.lua
+++ b/src/WorldEventSystem.lua
@@ -57,6 +57,26 @@ function WorldEventSystem:registerEvent(event)
     MDMLog.info("WorldEventSystem: registered event '" .. event.id .. "'")
 end
 
+-- Restore an active event from savegame.
+-- Called by MarketSerializer:load() after all events are registered.
+function WorldEventSystem:loadActiveEvent(id, endsAt, intensity)
+    local event = self.registry[id]
+    if not event then
+        MDMLog.warn("WorldEventSystem: cannot restore unknown event '" .. tostring(id) .. "'")
+        return
+    end
+
+    self.active[id] = { event = event, endsAt = endsAt, intensity = intensity }
+    
+    -- Re-trigger onFire to re-apply modifiers to the MarketEngine
+    if event.onFire then
+        event.onFire(intensity)
+    end
+    
+    MDMLog.info("WorldEventSystem: restored active event '" .. id .. "' (ends in " .. 
+        string.format("%.1f", (endsAt - (g_currentMission.time or 0)) / 60000) .. "m)")
+end
+
 -- Advance the event tick timer, expire any events past their endsAt, and
 -- probabilistically roll for new events when CHECK_INTERVAL elapses.
 -- dt is in-game milliseconds.

--- a/src/events/BiofuelInitiativeEvent.lua
+++ b/src/events/BiofuelInitiativeEvent.lua
@@ -1,0 +1,60 @@
+-- BiofuelInitiativeEvent.lua
+-- A government-led initiative to boost biofuel production.
+-- Increases demand and price for oilseeds and ethanol-friendly crops.
+--
+-- Intensity 0-1 maps to a +25%..+50% price boost:
+--   factor = 1.25 + intensity * 0.25
+--
+-- Affected crops: CANOLA, SUNFLOWER, SUGARBEET
+-- Duration: 30-60 in-game minutes | Cooldown: 120 in-game minutes | p = 0.03
+--
+-- Author: tison (dev-1)
+
+local EVENT_ID = "biofuel_initiative"
+
+local AFFECTED_CROPS = { "CANOLA", "SUNFLOWER", "SUGARBEET" }
+
+local function onFire(intensity)
+    if not g_MarketDynamics then return end
+
+    local factor = 1.25 + intensity * 0.25  -- 1.25x to 1.50x
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName)
+        if fillType then
+            g_MarketDynamics.marketEngine:addModifier({
+                id            = EVENT_ID .. "_" .. cropName,
+                fillTypeIndex = fillType.index,
+                factor        = factor,
+            })
+        end
+    end
+
+    MDMLog.info("BiofuelInitiativeEvent fired — energy crops up " .. string.format("%.0f%%", (factor - 1) * 100))
+end
+
+local function onExpire(intensity)
+    if not g_MarketDynamics then return end
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName)
+        if fillType then
+            g_MarketDynamics.marketEngine:removeModifierById(fillType.index, EVENT_ID .. "_" .. cropName)
+        end
+    end
+end
+
+-- Deferred registration
+MDM_pendingRegistrations = MDM_pendingRegistrations or {}
+table.insert(MDM_pendingRegistrations, {
+    id             = EVENT_ID,
+    name           = "Biofuel Initiative",
+    probability    = 0.03,
+    minIntensity   = 0.5,
+    maxIntensity   = 1.0,
+    cooldownMs     = 120 * 60 * 1000,   -- 2 hours
+    minDurationMs  = 30 * 60 * 1000,   -- 30-60 minutes
+    maxDurationMs  = 60 * 60 * 1000,
+    onFire         = onFire,
+    onExpire       = onExpire,
+})

--- a/src/events/LivestockBoomEvent.lua
+++ b/src/events/LivestockBoomEvent.lua
@@ -1,0 +1,59 @@
+-- LivestockBoomEvent.lua
+-- A surge in demand for livestock feed as regional herds expand.
+--
+-- Intensity 0-1 maps to a +15%..+40% price boost:
+--   factor = 1.15 + intensity * 0.25
+--
+-- Affected crops: GRASS, SILAGE, MAIZE (CORN)
+-- Duration: 20-40 in-game minutes | Cooldown: 90 in-game minutes | p = 0.04
+--
+-- Author: tison (dev-1)
+
+local EVENT_ID = "livestock_boom"
+
+local AFFECTED_CROPS = { "GRASS_WINDROW", "SILAGE", "MAIZE" }
+
+local function onFire(intensity)
+    if not g_MarketDynamics then return end
+
+    local factor = 1.15 + intensity * 0.25  -- 1.15x to 1.40x
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName)
+        if fillType then
+            g_MarketDynamics.marketEngine:addModifier({
+                id            = EVENT_ID .. "_" .. cropName,
+                fillTypeIndex = fillType.index,
+                factor        = factor,
+            })
+        end
+    end
+
+    MDMLog.info("LivestockBoomEvent fired — forage crops up " .. string.format("%.0f%%", (factor - 1) * 100))
+end
+
+local function onExpire(intensity)
+    if not g_MarketDynamics then return end
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName)
+        if fillType then
+            g_MarketDynamics.marketEngine:removeModifierById(fillType.index, EVENT_ID .. "_" .. cropName)
+        end
+    end
+end
+
+-- Deferred registration
+MDM_pendingRegistrations = MDM_pendingRegistrations or {}
+table.insert(MDM_pendingRegistrations, {
+    id             = EVENT_ID,
+    name           = "Livestock Feed Boom",
+    probability    = 0.04,
+    minIntensity   = 0.4,
+    maxIntensity   = 1.0,
+    cooldownMs     = 90 * 60 * 1000,   -- 1.5 hours
+    minDurationMs  = 20 * 60 * 1000,   -- 20-40 minutes
+    maxDurationMs  = 40 * 60 * 1000,
+    onFire         = onFire,
+    onExpire       = onExpire,
+})

--- a/src/events/PestOutbreakEvent.lua
+++ b/src/events/PestOutbreakEvent.lua
@@ -1,0 +1,60 @@
+-- PestOutbreakEvent.lua
+-- A sudden blight or pest infestation in a major root-crop region.
+-- Affects Potato and Sugarbeet prices significantly as supply collapses.
+--
+-- Intensity 0-1 maps to a +20%..+60% price boost:
+--   factor = 1.20 + intensity * 0.40
+--
+-- Affected crops: POTATO, SUGARBEET
+-- Duration: 15-30 in-game minutes | Cooldown: 60 in-game minutes | p = 0.05
+--
+-- Author: tison (dev-1)
+
+local EVENT_ID = "pest_outbreak"
+
+local AFFECTED_CROPS = { "POTATO", "SUGARBEET" }
+
+local function onFire(intensity)
+    if not g_MarketDynamics then return end
+
+    local factor = 1.20 + intensity * 0.40  -- 1.20x to 1.60x
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName)
+        if fillType then
+            g_MarketDynamics.marketEngine:addModifier({
+                id            = EVENT_ID .. "_" .. cropName,
+                fillTypeIndex = fillType.index,
+                factor        = factor,
+            })
+        end
+    end
+
+    MDMLog.info("PestOutbreakEvent fired — root crops up " .. string.format("%.0f%%", (factor - 1) * 100))
+end
+
+local function onExpire(intensity)
+    if not g_MarketDynamics then return end
+
+    for _, cropName in ipairs(AFFECTED_CROPS) do
+        local fillType = g_fillTypeManager:getFillTypeByName(cropName)
+        if fillType then
+            g_MarketDynamics.marketEngine:removeModifierById(fillType.index, EVENT_ID .. "_" .. cropName)
+        end
+    end
+end
+
+-- Deferred registration
+MDM_pendingRegistrations = MDM_pendingRegistrations or {}
+table.insert(MDM_pendingRegistrations, {
+    id             = EVENT_ID,
+    name           = "Root Crop Blight",
+    probability    = 0.05,
+    minIntensity   = 0.3,
+    maxIntensity   = 1.0,
+    cooldownMs     = 60 * 60 * 1000,   -- 1 hour
+    minDurationMs  = 15 * 60 * 1000,   -- 15-30 minutes
+    maxDurationMs  = 30 * 60 * 1000,
+    onFire         = onFire,
+    onExpire       = onExpire,
+})


### PR DESCRIPTION
## Summary
Restores corrupted mod files (modDesc.xml, main.lua) and implements Phase 2 features:
- **Engine Refinement:** Dampened volatility, mean reversion, seasonal base prices.
- **Persistence:** Serializer now saves active events, price history, and market modifiers.
- **New Events:** Added 'Pest Outbreak', 'Livestock Boom', and 'Biofuel Initiative'.
- **Fix:** Restored critical files that were accidentally overwritten.