### PR TITLE
fix: dedi contract creation pcall + close issues #81 #78

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Claude Code files
+.claude/
+
+# Temporary files
+*.tmp
+*.bak
+*~
+
+*.skill
+
+# OS files
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Build artifacts
+*.zip.old
+*_temp/
+
+# Tool outputs
+GLOBAL_LEAK_AUDIT.md

--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,7 @@ if command -v zip &>/dev/null; then
         --exclude "./__MACOSX/*" \
         --exclude "./*.DS_Store" \
         --exclude "./*.zip" \
+        --exclude "./tools/*" 
         --exclude "./xml/MDMEventConfig_example.xml"
     echo "  Built via zip"
 else

--- a/src/events/MDMContractRequestEvent.lua
+++ b/src/events/MDMContractRequestEvent.lua
@@ -84,33 +84,40 @@ end
 function MDMContractRequestEvent:run(connection)
     if connection:getIsServer() then return end
 
-    local userId = g_currentMission.userManager:getUserIdByConnection(connection)
-    local farm = userId ~= nil and g_farmManager:getFarmByUserId(userId) or nil
-    local isFarmManager = farm ~= nil and farm:isUserFarmManager(userId)
-    local user = userId ~= nil and g_currentMission.userManager:getUserByUserId(userId) or nil
-    local isAdmin = user ~= nil and (user.isMasterUser == true or user.isAdmin == true)
+    local ok, err = pcall(function()
+        local userId = g_currentMission.userManager:getUserIdByConnection(connection)
+        local farm = userId ~= nil and g_farmManager:getFarmByUserId(userId) or nil
+        local isFarmManager = farm ~= nil and farm:isUserFarmManager(userId)
+        local user = userId ~= nil and g_currentMission.userManager:getUserByUserId(userId) or nil
+        local isAdmin = user ~= nil and (user.isMasterUser == true or user.isAdmin == true)
 
-    if self.action == MDMContractRequestEvent.ACTION_CREATE then
-        -- Security: Non-farm-managers can only create contracts for their own farm
-        if not isAdmin and not isFarmManager then
-            if farm == nil or self.params.farmId ~= farm.farmId then
-                MDMLog.warn("MDMContractRequestEvent: unauthorized farmId in contract creation from client " .. tostring(userId))
+        if self.action == MDMContractRequestEvent.ACTION_CREATE then
+            -- Security: Non-farm-managers can only create contracts for their own farm
+            if not isAdmin and not isFarmManager then
+                if farm == nil or self.params.farmId ~= farm.farmId then
+                    MDMLog.warn("MDMContractRequestEvent: unauthorized CREATE from userId=" .. tostring(userId)
+                        .. " farmId=" .. tostring(self.params.farmId))
+                    return
+                end
+            end
+        else
+            -- Security: Action on existing contract.
+            -- Allow if user is Admin OR Farm Manager OR the contract belongs to their farm.
+            local fm = g_MarketDynamics and g_MarketDynamics.futuresMarket
+            local contract = fm and fm.contracts and fm.contracts[self.params.contractId]
+            local isOwner = contract ~= nil and farm ~= nil and contract.farmId == farm.farmId
+
+            if not isAdmin and not isFarmManager and not isOwner then
+                MDMLog.warn("MDMContractRequestEvent: unauthorized action " .. tostring(self.action)
+                    .. " from userId=" .. tostring(userId))
                 return
             end
         end
-    else
-        -- Security: Action on existing contract. 
-        -- Allow if user is Admin OR Farm Manager OR the contract belongs to their farm.
-        local fm = g_MarketDynamics and g_MarketDynamics.futuresMarket
-        local contract = fm and fm.contracts and fm.contracts[self.params.contractId]
-        
-        local isOwner = contract ~= nil and farm ~= nil and contract.farmId == farm.farmId
 
-        if not isAdmin and not isFarmManager and not isOwner then
-            MDMLog.warn("MDMContractRequestEvent: unauthorized action attempt from client " .. tostring(userId))
-            return
-        end
+        MDMContractRequestEvent.execute(self.action, self.params)
+    end)
+
+    if not ok then
+        MDMLog.error("MDMContractRequestEvent:run error: " .. tostring(err))
     end
-
-    MDMContractRequestEvent.execute(self.action, self.params)
 end

--- a/tools/check-global-leaks.sh
+++ b/tools/check-global-leaks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Pre-commit hook to detect global variable leaks
+# Install: Copy to .git/hooks/pre-commit and make executable
+
+echo "Checking for global variable leaks..."
+
+# Pattern: indented assignment that looks like parameter reassignment
+# Matches: "    variable = variable or"
+LEAKS=$(grep -rn '^\s\+[a-z][a-zA-Z0-9_]*\s*=\s*[a-z][a-zA-Z0-9_]*\s*or\s*' src/ --include="*.lua" | grep -v 'local ')
+
+if [ -n "$LEAKS" ]; then
+    echo "ERROR: Potential global variable leaks detected!"
+    echo ""
+    echo "The following lines reassign parameters without 'local' keyword:"
+    echo "$LEAKS"
+    echo ""
+    echo "FIX: Add 'local' keyword before variable name:"
+    echo "  BEFORE: cost = cost or 0"
+    echo "  AFTER:  local cost = cost or 0"
+    echo ""
+    exit 1
+fi
+
+echo "No global leaks detected!"
+exit 0

--- a/tools/check-global-leaks.sh
+++ b/tools/check-global-leaks.sh
@@ -6,7 +6,10 @@ echo "Checking for global variable leaks..."
 
 # Pattern: indented assignment that looks like parameter reassignment
 # Matches: "    variable = variable or"
-LEAKS=$(grep -rn '^\s\+[a-z][a-zA-Z0-9_]*\s*=\s*[a-z][a-zA-Z0-9_]*\s*or\s*' src/ --include="*.lua" | grep -v 'local ')
+# Excludes: trailing-comma lines (table field assignments) and local declarations
+LEAKS=$(grep -rn '^\s\+[a-z][a-zA-Z0-9_]*\s*=\s*[a-z][a-zA-Z0-9_]*\s\+or\s\+' src/ --include="*.lua" \
+    | grep -v 'local ' \
+    | grep -v ',\s*$')
 
 if [ -n "$LEAKS" ]; then
     echo "ERROR: Potential global variable leaks detected!"

--- a/tools/codebase_stats.js
+++ b/tools/codebase_stats.js
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+/**
+ * FS25_UsedPlus Codebase Statistics Generator v2.0
+ *
+ * Generates comprehensive, verified statistics about the codebase.
+ * Separates mod code from project support files (docs, tools, etc.)
+ * and produces both terminal output and README-ready markdown.
+ *
+ * Usage:
+ *   node codebase_stats.js            # Full terminal report
+ *   node codebase_stats.js --markdown  # README-ready markdown snippet
+ *
+ * Author: Claude & Samantha
+ * Version: 2.0.0
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MOD_ROOT = path.dirname(__dirname);
+
+// ─── Terminal colors ──────────────────────────────────────────────────────────
+const c = {
+    cyan:    '\x1b[96m',
+    green:   '\x1b[92m',
+    yellow:  '\x1b[93m',
+    red:     '\x1b[91m',
+    dim:     '\x1b[2m',
+    reset:   '\x1b[0m',
+    bold:    '\x1b[1m',
+};
+
+// ─── Directories to skip entirely ────────────────────────────────────────────
+const SKIP_DIRS = new Set([
+    'node_modules', '.git', 'dist', '.build_temp',
+]);
+
+// ─── "Project support" top-level dirs (not shipped mod code) ─────────────────
+const SUPPORT_DIRS = new Set([
+    'docs', 'screenshots', 'FS25_AI_Coding_Reference', '.github', 'tools',
+]);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getAllFiles(dir, fileList = []) {
+    for (const entry of fs.readdirSync(dir)) {
+        const full = path.join(dir, entry);
+        const stat = fs.statSync(full);
+        if (stat.isDirectory()) {
+            if (!SKIP_DIRS.has(entry)) getAllFiles(full, fileList);
+        } else {
+            fileList.push(full);
+        }
+    }
+    return fileList;
+}
+
+function countLines(filePath) {
+    try {
+        const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+        const total = lines.length;
+        const code = lines.filter(l => l.trim().length > 0).length;
+        return { total, code, blank: total - code };
+    } catch {
+        return { total: 0, code: 0, blank: 0 };
+    }
+}
+
+function n(filePath) {
+    // Normalize to forward slashes for consistent matching
+    return path.relative(MOD_ROOT, filePath).replace(/\\/g, '/');
+}
+
+function ext(filePath) {
+    return path.extname(filePath).toLowerCase() || '(none)';
+}
+
+function formatBytes(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
+    if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + ' MB';
+    return (bytes / 1073741824).toFixed(1) + ' GB';
+}
+
+function formatNum(num) {
+    return num.toLocaleString();
+}
+
+function topDir(relPath) {
+    const parts = relPath.split('/');
+    return parts.length > 1 ? parts[0] : '(root)';
+}
+
+function isModCode(relPath) {
+    const top = topDir(relPath);
+    return !SUPPORT_DIRS.has(top);
+}
+
+// ─── Data collection ──────────────────────────────────────────────────────────
+
+function collectData() {
+    const allFiles = getAllFiles(MOD_ROOT);
+    const data = {
+        allFiles: [],
+        modFiles: [],
+        supportFiles: [],
+        byExt: {},           // ext → { files: [], lines: {total,code,blank} }
+        byDir: {},            // top-level dir → count
+        luaFiles: [],         // { rel, lines } for all Lua
+    };
+
+    for (const filePath of allFiles) {
+        const rel = n(filePath);
+        const e = ext(filePath);
+        const top = topDir(rel);
+        const isMod = isModCode(rel);
+
+        data.allFiles.push({ rel, filePath, ext: e, isMod });
+        if (isMod) data.modFiles.push({ rel, filePath, ext: e });
+        else data.supportFiles.push({ rel, filePath, ext: e });
+
+        // By extension
+        if (!data.byExt[e]) data.byExt[e] = { files: [], lines: { total: 0, code: 0, blank: 0 } };
+        data.byExt[e].files.push(rel);
+
+        // Count lines for text-based code files (skip JSON — inflated by lock files)
+        if (['.lua', '.js', '.xml', '.md', '.yml', '.ps1', '.sh', '.bat'].includes(e)) {
+            const lines = countLines(filePath);
+            data.byExt[e].lines.total += lines.total;
+            data.byExt[e].lines.code += lines.code;
+            data.byExt[e].lines.blank += lines.blank;
+
+            if (e === '.lua') {
+                data.luaFiles.push({ rel, lines: lines.code });
+            }
+        }
+
+        // By directory
+        data.byDir[top] = (data.byDir[top] || 0) + 1;
+    }
+
+    return data;
+}
+
+// ─── Feature counting (verified patterns) ─────────────────────────────────────
+
+function countFeatures(data) {
+    const luaRels = data.allFiles.filter(f => f.ext === '.lua').map(f => f.rel);
+    const xmlRels = data.allFiles.filter(f => f.ext === '.xml').map(f => f.rel);
+
+    // GUI XML — all XML files in gui/ directory
+    const guiXml = xmlRels.filter(f => f.startsWith('gui/') && f.endsWith('.xml'));
+    const dialogXml = guiXml.filter(f => f.includes('Dialog'));
+    const frameXml = guiXml.filter(f => f.includes('Frame'));
+    const otherGuiXml = guiXml.filter(f => !f.includes('Dialog') && !f.includes('Frame'));
+
+    // GUI Lua — all Lua files in src/gui/
+    const guiLua = luaRels.filter(f => f.startsWith('src/gui/'));
+    const dialogLua = guiLua.filter(f => f.includes('Dialog'));
+
+    // Managers — all Lua files in src/managers/ (including sub-directories)
+    const managers = luaRels.filter(f => f.startsWith('src/managers/'));
+
+    // Events — all Lua files in src/events/
+    const events = luaRels.filter(f => f.startsWith('src/events/'));
+
+    // Specializations — all Lua files in src/specializations/
+    const specs = luaRels.filter(f => f.startsWith('src/specializations/'));
+
+    // Extensions — all Lua files in src/extensions/
+    const extensions = luaRels.filter(f => f.startsWith('src/extensions/'));
+
+    // Utilities — all Lua files in src/utils/
+    const utilities = luaRels.filter(f => f.startsWith('src/utils/'));
+
+    // Vehicle scripts — Lua files in vehicles/ root
+    const vehicleScripts = luaRels.filter(f => f.startsWith('vehicles/') && f.endsWith('.lua'));
+
+    // Core — Lua files in src/core/ and src/data/
+    const coreFiles = luaRels.filter(f => f.startsWith('src/core/') || f.startsWith('src/data/'));
+
+    // Translation files — XML files matching translations/translation_*.xml
+    const translationFiles = xmlRels.filter(f => /^translations\/translation_\w+\.xml$/.test(f));
+
+    // Translation key count from English file
+    let translationKeys = 0;
+    const enFile = path.join(MOD_ROOT, 'translations', 'translation_en.xml');
+    if (fs.existsSync(enFile)) {
+        const content = fs.readFileSync(enFile, 'utf8');
+        const matches = content.match(/<e k="/g);
+        translationKeys = matches ? matches.length : 0;
+    }
+
+    // Icons — PNG files in gui/icons/
+    const icons = data.allFiles.filter(f => f.rel.startsWith('gui/icons/') && f.ext === '.png');
+
+    // Assets
+    const ddsFiles = data.allFiles.filter(f => f.ext === '.dds');
+    const i3dFiles = data.allFiles.filter(f => f.ext === '.i3d');
+    const shapeFiles = data.allFiles.filter(f => f.ext === '.shapes');
+
+    // Tools
+    const toolFiles = data.allFiles.filter(f => f.rel.startsWith('tools/'));
+
+    return {
+        guiXml, dialogXml, frameXml, otherGuiXml,
+        guiLua, dialogLua,
+        managers, events, specs, extensions, utilities,
+        vehicleScripts, coreFiles,
+        translationFiles, translationKeys,
+        icons, ddsFiles, i3dFiles, shapeFiles, toolFiles,
+    };
+}
+
+// ─── Per-category line counts (for detailed breakdown) ────────────────────────
+
+function categoryLines(fileList) {
+    let total = 0;
+    const perFile = [];
+    for (const rel of fileList) {
+        const lines = countLines(path.join(MOD_ROOT, rel));
+        total += lines.code;
+        perFile.push({ rel: path.basename(rel, '.lua'), lines: lines.code });
+    }
+    perFile.sort((a, b) => b.lines - a.lines);
+    return { total, perFile };
+}
+
+// ─── Terminal output ──────────────────────────────────────────────────────────
+
+function printTerminal(data, features) {
+    const lua = data.byExt['.lua']?.lines || { total: 0, code: 0, blank: 0 };
+    const xml = data.byExt['.xml']?.lines || { total: 0, code: 0, blank: 0 };
+    const js  = data.byExt['.js']?.lines  || { total: 0, code: 0, blank: 0 };
+    const totalCode = lua.code + xml.code + js.code;
+    const totalSize = data.allFiles.reduce((sum, f) => {
+        try { return sum + fs.statSync(f.filePath).size; } catch { return sum; }
+    }, 0);
+
+    console.log();
+    console.log(c.cyan + '═══════════════════════════════════════════════════════════════════════');
+    console.log('  FS25_UsedPlus — Codebase Statistics v2.0');
+    console.log('═══════════════════════════════════════════════════════════════════════' + c.reset);
+
+    // ── Overall Summary ──
+    console.log();
+    console.log(c.bold + '  OVERALL SUMMARY' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Total Files:        ${formatNum(data.allFiles.length)}`);
+    console.log(`    Mod Code:         ${formatNum(data.modFiles.length)}`);
+    console.log(`    Project Support:  ${formatNum(data.supportFiles.length)} ${c.dim}(docs, tools, .github, etc.)${c.reset}`);
+    console.log(`  Total Size:         ${formatBytes(totalSize)}`);
+
+    // ── Code Metrics ──
+    console.log();
+    console.log(c.bold + '  CODE METRICS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Lua:                ${formatNum(lua.code)} lines  ${c.dim}(${data.byExt['.lua']?.files.length || 0} files)${c.reset}`);
+    console.log(`  XML:                ${formatNum(xml.code)} lines  ${c.dim}(${data.byExt['.xml']?.files.length || 0} files)${c.reset}`);
+    console.log(`  JavaScript:         ${formatNum(js.code)} lines  ${c.dim}(${data.byExt['.js']?.files.length || 0} files)${c.reset}`);
+    console.log(`  ${c.green}Total Code:         ${formatNum(totalCode)} lines${c.reset}`);
+
+    // ── Files by Type ──
+    console.log();
+    console.log(c.bold + '  FILES BY TYPE' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  ${c.dim}${'Type'.padEnd(12)} ${'Count'.padStart(5)}   Lines (Code / Blank)${c.reset}`);
+
+    const sorted = Object.entries(data.byExt).sort((a, b) => b[1].files.length - a[1].files.length);
+    for (const [ext, info] of sorted) {
+        const count = String(info.files.length).padStart(5);
+        if (info.lines.total > 0) {
+            console.log(`  ${ext.padEnd(12)} ${count}   ${formatNum(info.lines.code).padStart(7)} / ${formatNum(info.lines.blank).padStart(5)}`);
+        } else {
+            console.log(`  ${ext.padEnd(12)} ${count}   ${c.dim}(binary)${c.reset}`);
+        }
+    }
+
+    // ── Architecture ──
+    console.log();
+    console.log(c.bold + '  ARCHITECTURE' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  GUI Screens:        ${features.guiXml.length} XML  ${c.dim}(${features.dialogXml.length} dialogs, ${features.frameXml.length} frames, ${features.otherGuiXml.length} panels)${c.reset}`);
+    console.log(`  GUI Lua:            ${features.guiLua.length} files  ${c.dim}(${features.dialogLua.length} dialog controllers)${c.reset}`);
+    console.log(`  Managers:           ${features.managers.length} files`);
+    console.log(`  Network Events:     ${features.events.length} files`);
+    console.log(`  Specializations:    ${features.specs.length} files`);
+    console.log(`  Extensions:         ${features.extensions.length} files`);
+    console.log(`  Utilities:          ${features.utilities.length} files`);
+    console.log(`  Vehicle Scripts:    ${features.vehicleScripts.length} files`);
+    console.log(`  Core/Data:          ${features.coreFiles.length} files`);
+
+    // ── Assets ──
+    console.log();
+    console.log(c.bold + '  ASSETS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  DDS Textures:       ${features.ddsFiles.length}`);
+    console.log(`  GUI Icons (PNG):    ${features.icons.length}`);
+    console.log(`  3D Models (I3D):    ${features.i3dFiles.length}`);
+    console.log(`  Shape Files:        ${features.shapeFiles.length}`);
+
+    // ── Localization ──
+    console.log();
+    console.log(c.bold + '  LOCALIZATION' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Languages:          ${features.translationFiles.length}`);
+    console.log(`  Translation Keys:   ${formatNum(features.translationKeys)}`);
+
+    // ── Top 10 Largest Lua Files ──
+    console.log();
+    console.log(c.bold + '  TOP 10 LARGEST LUA FILES' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    const top10 = data.luaFiles.sort((a, b) => b.lines - a.lines).slice(0, 10);
+    for (let i = 0; i < top10.length; i++) {
+        const f = top10[i];
+        const name = path.basename(f.rel, '.lua');
+        const warn = f.lines > 1500 ? ` ${c.red}⚠ EXCEEDS 1500 LINE LIMIT${c.reset}` : '';
+        console.log(`  ${String(i + 1).padStart(2)}. ${name.padEnd(35)} ${formatNum(f.lines).padStart(6)} lines${warn}`);
+    }
+
+    // ── Detailed Category Breakdowns ──
+    console.log();
+    console.log(c.bold + '  DETAILED CATEGORY BREAKDOWNS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+
+    const categories = [
+        ['Managers', features.managers],
+        ['Events', features.events],
+        ['Specializations', features.specs],
+        ['Extensions', features.extensions],
+        ['Utilities', features.utilities],
+    ];
+
+    for (const [label, files] of categories) {
+        const cl = categoryLines(files);
+        const topFiles = cl.perFile.slice(0, 4).map(f => `${f.rel} (${formatNum(f.lines)})`).join(' • ');
+        console.log(`  ${c.yellow}${label}${c.reset} (${formatNum(cl.total)} lines):`);
+        console.log(`    ${topFiles}`);
+    }
+
+    // ── Directory Breakdown ──
+    console.log();
+    console.log(c.bold + '  FILES BY DIRECTORY' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    const sortedDirs = Object.entries(data.byDir).sort((a, b) => b[1] - a[1]);
+    for (const [dir, count] of sortedDirs) {
+        const tag = SUPPORT_DIRS.has(dir) ? ` ${c.dim}(support)${c.reset}` : '';
+        console.log(`  ${dir.padEnd(30)} ${String(count).padStart(4)} files${tag}`);
+    }
+
+    // ── Development Tools ──
+    console.log();
+    console.log(c.bold + '  DEVELOPMENT TOOLS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Tool Scripts:       ${features.toolFiles.length} files`);
+
+    console.log();
+    console.log(c.cyan + '═══════════════════════════════════════════════════════════════════════' + c.reset);
+    console.log();
+}
+
+// ─── Markdown output (for README.md) ──────────────────────────────────────────
+
+function printMarkdown(data, features) {
+    const lua = data.byExt['.lua']?.lines || { total: 0, code: 0, blank: 0 };
+    const xml = data.byExt['.xml']?.lines || { total: 0, code: 0, blank: 0 };
+    const js  = data.byExt['.js']?.lines  || { total: 0, code: 0, blank: 0 };
+    const totalCode = lua.code + xml.code + js.code;
+
+    const luaCount = data.byExt['.lua']?.files.length || 0;
+    const xmlCount = data.byExt['.xml']?.files.length || 0;
+
+    const out = [];
+    out.push('### Codebase Statistics');
+    out.push('');
+    out.push(`- **${formatNum(totalCode)} lines of code** (${formatNum(lua.code)} Lua • ${formatNum(xml.code)} XML • ${formatNum(js.code)} JavaScript)`);
+    out.push(`- **${formatNum(data.modFiles.length)} mod files** (${luaCount} Lua • ${xmlCount} XML • ${features.icons.length} icons • ${features.ddsFiles.length} textures • ${features.i3dFiles.length} 3D models)`);
+    out.push(`- **${features.guiXml.length} GUI screens** (${features.dialogXml.length} dialogs, ${features.frameXml.length} frames, ${features.otherGuiXml.length} panels)`);
+    out.push(`- **${features.managers.length} manager classes** orchestrating game systems`);
+    out.push(`- **${features.events.length} network event modules** for multiplayer sync`);
+    out.push(`- **${features.specs.length} specialization modules** for maintenance systems`);
+    out.push(`- **${features.extensions.length} extension hooks** into base game systems`);
+    out.push(`- **${features.utilities.length} utility/helper modules** for shared logic`);
+    out.push(`- **${features.toolFiles.length} development tools** for build, validation & stats`);
+    out.push(`- **${formatNum(features.translationKeys)} localization keys** translated to ${features.translationFiles.length} languages`);
+    out.push(`- **5 months development** (November 2025 - present)`);
+    out.push('');
+
+    // Detailed breakdown
+    out.push('<details>');
+    out.push('<summary><b>📊 Detailed Architecture Breakdown</b></summary>');
+    out.push('');
+
+    const categories = [
+        ['Manager Layer', features.managers],
+        ['Network Events', features.events],
+        ['Specializations', features.specs],
+        ['Extensions', features.extensions],
+        ['Utilities', features.utilities],
+    ];
+
+    for (const [label, files] of categories) {
+        const cl = categoryLines(files);
+        const topFiles = cl.perFile.slice(0, 4).map(f => `${f.rel} (${formatNum(f.lines)})`).join(' • ');
+        out.push(`**${label}** (${formatNum(cl.total)} lines):`);
+        out.push(`- ${topFiles}`);
+        out.push('');
+    }
+
+    // Dialog categories — count by name pattern
+    const dialogCategories = {
+        'Finance System': features.dialogLua.filter(f => /Finance|Loan|Credit|Payment|Lease|Repossession|Deal/.test(f)),
+        'Marketplace - Buying': features.dialogLua.filter(f => /Search|Used|Preview|Inspection|Negotiation/.test(f)),
+        'Marketplace - Selling': features.dialogLua.filter(f => /Sale|Sell|Offer/.test(f)),
+        'Maintenance & Repair': features.dialogLua.filter(f => /Repair|Maintenance|Fluid|Tire|FaultTracer/.test(f)),
+        'Service Truck': features.dialogLua.filter(f => /ServiceTruck/.test(f)),
+        'Purchase System': features.dialogLua.filter(f => /Purchase|UnifiedLand/.test(f)),
+    };
+
+    out.push('**Dialog Categories**:');
+    const cats = Object.entries(dialogCategories).filter(([, v]) => v.length > 0);
+    out.push('- ' + cats.map(([k, v]) => `${k} (${v.length})`).join(' • '));
+    out.push('');
+    out.push('</details>');
+
+    console.log(out.join('\n'));
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+function main() {
+    const markdownMode = process.argv.includes('--markdown');
+
+    const data = collectData();
+    const features = countFeatures(data);
+
+    if (markdownMode) {
+        printMarkdown(data, features);
+    } else {
+        printTerminal(data, features);
+
+        // Also show the markdown snippet at the end for convenience
+        console.log(c.bold + '  README-READY MARKDOWN (copy below):' + c.reset);
+        console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+        console.log();
+        printMarkdown(data, features);
+    }
+}
+
+main();

--- a/tools/codebase_stats.js
+++ b/tools/codebase_stats.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * FS25_UsedPlus Codebase Statistics Generator v2.0
+ * FS25_MarketDynamics Codebase Statistics Generator v2.0
  *
  * Generates comprehensive, verified statistics about the codebase.
  * Separates mod code from project support files (docs, tools, etc.)
@@ -148,51 +148,51 @@ function countFeatures(data) {
     const luaRels = data.allFiles.filter(f => f.ext === '.lua').map(f => f.rel);
     const xmlRels = data.allFiles.filter(f => f.ext === '.xml').map(f => f.rel);
 
-    // GUI XML — all XML files in gui/ directory
-    const guiXml = xmlRels.filter(f => f.startsWith('gui/') && f.endsWith('.xml'));
+    // GUI XML — xml/gui/ dialogs + gui/settingsPage.xml
+    const guiXml = xmlRels.filter(f => (f.startsWith('xml/gui/') || f.startsWith('gui/')) && f.endsWith('.xml'));
     const dialogXml = guiXml.filter(f => f.includes('Dialog'));
-    const frameXml = guiXml.filter(f => f.includes('Frame'));
-    const otherGuiXml = guiXml.filter(f => !f.includes('Dialog') && !f.includes('Frame'));
+    const frameXml = guiXml.filter(f => f.includes('Screen') || f.includes('Frame'));
+    const otherGuiXml = guiXml.filter(f => !f.includes('Dialog') && !f.includes('Screen') && !f.includes('Frame'));
 
     // GUI Lua — all Lua files in src/gui/
     const guiLua = luaRels.filter(f => f.startsWith('src/gui/'));
     const dialogLua = guiLua.filter(f => f.includes('Dialog'));
 
-    // Managers — all Lua files in src/managers/ (including sub-directories)
-    const managers = luaRels.filter(f => f.startsWith('src/managers/'));
+    // Core engine — root-level src files
+    const managers = luaRels.filter(f => /^src\/(MarketDynamics|MarketEngine|WorldEventSystem|FuturesMarket|MarketSerializer|PriceHook|MDMHUD)\.lua$/.test(f));
 
-    // Events — all Lua files in src/events/
+    // Network events — src/events/
     const events = luaRels.filter(f => f.startsWith('src/events/'));
 
-    // Specializations — all Lua files in src/specializations/
-    const specs = luaRels.filter(f => f.startsWith('src/specializations/'));
+    // Specializations — none in this mod
+    const specs = [];
 
-    // Extensions — all Lua files in src/extensions/
-    const extensions = luaRels.filter(f => f.startsWith('src/extensions/'));
+    // Integrations — BC/UP/RWE bridges
+    const extensions = luaRels.filter(f => /^src\/(BCIntegration|UPIntegration|RWEIntegration)\.lua$/.test(f));
 
-    // Utilities — all Lua files in src/utils/
-    const utilities = luaRels.filter(f => f.startsWith('src/utils/'));
+    // Utilities — AdminCommands, MDMEventConfig, DebugHUD
+    const utilities = luaRels.filter(f => /^src\/(AdminCommands|MDMEventConfig|DebugHUD)\.lua$/.test(f));
 
-    // Vehicle scripts — Lua files in vehicles/ root
-    const vehicleScripts = luaRels.filter(f => f.startsWith('vehicles/') && f.endsWith('.lua'));
+    // Entry point
+    const vehicleScripts = luaRels.filter(f => f === 'main.lua');
 
-    // Core — Lua files in src/core/ and src/data/
-    const coreFiles = luaRels.filter(f => f.startsWith('src/core/') || f.startsWith('src/data/'));
+    // Config/Logger
+    const coreFiles = luaRels.filter(f => /^src\/Logger\.lua$/.test(f));
 
     // Translation files — XML files matching translations/translation_*.xml
     const translationFiles = xmlRels.filter(f => /^translations\/translation_\w+\.xml$/.test(f));
 
-    // Translation key count from English file
+    // Translation key count from English file (uses <text name="..." /> format)
     let translationKeys = 0;
     const enFile = path.join(MOD_ROOT, 'translations', 'translation_en.xml');
     if (fs.existsSync(enFile)) {
         const content = fs.readFileSync(enFile, 'utf8');
-        const matches = content.match(/<e k="/g);
+        const matches = content.match(/<text name="/g);
         translationKeys = matches ? matches.length : 0;
     }
 
-    // Icons — PNG files in gui/icons/
-    const icons = data.allFiles.filter(f => f.rel.startsWith('gui/icons/') && f.ext === '.png');
+    // Icons — PNG files anywhere
+    const icons = data.allFiles.filter(f => f.ext === '.png');
 
     // Assets
     const ddsFiles = data.allFiles.filter(f => f.ext === '.dds');
@@ -239,7 +239,7 @@ function printTerminal(data, features) {
 
     console.log();
     console.log(c.cyan + '═══════════════════════════════════════════════════════════════════════');
-    console.log('  FS25_UsedPlus — Codebase Statistics v2.0');
+    console.log('  FS25_MarketDynamics — Codebase Statistics v2.0');
     console.log('═══════════════════════════════════════════════════════════════════════' + c.reset);
 
     // ── Overall Summary ──
@@ -280,15 +280,14 @@ function printTerminal(data, features) {
     console.log();
     console.log(c.bold + '  ARCHITECTURE' + c.reset);
     console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
-    console.log(`  GUI Screens:        ${features.guiXml.length} XML  ${c.dim}(${features.dialogXml.length} dialogs, ${features.frameXml.length} frames, ${features.otherGuiXml.length} panels)${c.reset}`);
+    console.log(`  GUI Screens:        ${features.guiXml.length} XML  ${c.dim}(${features.dialogXml.length} dialogs, ${features.frameXml.length} screens, ${features.otherGuiXml.length} panels)${c.reset}`);
     console.log(`  GUI Lua:            ${features.guiLua.length} files  ${c.dim}(${features.dialogLua.length} dialog controllers)${c.reset}`);
-    console.log(`  Managers:           ${features.managers.length} files`);
-    console.log(`  Network Events:     ${features.events.length} files`);
-    console.log(`  Specializations:    ${features.specs.length} files`);
-    console.log(`  Extensions:         ${features.extensions.length} files`);
+    console.log(`  Core Engine:        ${features.managers.length} files`);
+    console.log(`  World Events:       ${features.events.length} files`);
+    console.log(`  Integrations:       ${features.extensions.length} files`);
     console.log(`  Utilities:          ${features.utilities.length} files`);
-    console.log(`  Vehicle Scripts:    ${features.vehicleScripts.length} files`);
-    console.log(`  Core/Data:          ${features.coreFiles.length} files`);
+    console.log(`  Entry Point:        ${features.vehicleScripts.length} files`);
+    console.log(`  Logger:             ${features.coreFiles.length} files`);
 
     // ── Assets ──
     console.log();
@@ -324,10 +323,10 @@ function printTerminal(data, features) {
     console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
 
     const categories = [
-        ['Managers', features.managers],
-        ['Events', features.events],
-        ['Specializations', features.specs],
-        ['Extensions', features.extensions],
+        ['Core Engine', features.managers],
+        ['Network Events', features.events],
+        ['GUI Screens', features.guiLua],
+        ['Integrations', features.extensions],
         ['Utilities', features.utilities],
     ];
 
@@ -392,10 +391,10 @@ function printMarkdown(data, features) {
     out.push('');
 
     const categories = [
-        ['Manager Layer', features.managers],
+        ['Core Engine', features.managers],
         ['Network Events', features.events],
-        ['Specializations', features.specs],
-        ['Extensions', features.extensions],
+        ['GUI Screens', features.guiLua],
+        ['Integrations', features.extensions],
         ['Utilities', features.utilities],
     ];
 
@@ -409,12 +408,10 @@ function printMarkdown(data, features) {
 
     // Dialog categories — count by name pattern
     const dialogCategories = {
-        'Finance System': features.dialogLua.filter(f => /Finance|Loan|Credit|Payment|Lease|Repossession|Deal/.test(f)),
-        'Marketplace - Buying': features.dialogLua.filter(f => /Search|Used|Preview|Inspection|Negotiation/.test(f)),
-        'Marketplace - Selling': features.dialogLua.filter(f => /Sale|Sell|Offer/.test(f)),
-        'Maintenance & Repair': features.dialogLua.filter(f => /Repair|Maintenance|Fluid|Tire|FaultTracer/.test(f)),
-        'Service Truck': features.dialogLua.filter(f => /ServiceTruck/.test(f)),
-        'Purchase System': features.dialogLua.filter(f => /Purchase|UnifiedLand/.test(f)),
+        'Market Browser': features.dialogLua.filter(f => /Browse|Market/.test(f)),
+        'Contracts': features.dialogLua.filter(f => /Contract/.test(f)),
+        'Event Settings': features.dialogLua.filter(f => /MDMEvent/.test(f)),
+        'Admin & Input': features.dialogLua.filter(f => /Admin|Custom/.test(f)),
     };
 
     out.push('**Dialog Categories**:');

--- a/tools/extract_log_errors.ps1
+++ b/tools/extract_log_errors.ps1
@@ -1,0 +1,274 @@
+<#
+.SYNOPSIS
+    Extracts MarketDynamics-related errors and warnings from FS25 game log.
+
+.DESCRIPTION
+    Parses the Farming Simulator 25 log.txt file and extracts all entries
+    related to the MarketDynamics mod, categorizing them by severity and type.
+
+.PARAMETER LogPath
+    Path to the log.txt file. Defaults to the standard FS25 location.
+
+.PARAMETER OutputFile
+    Optional path to save the report. If not specified, outputs to console.
+
+.PARAMETER LastNLines
+    Only analyze the last N lines of the log (useful for large logs).
+
+.EXAMPLE
+    .\extract_log_errors.ps1
+
+.EXAMPLE
+    .\extract_log_errors.ps1 -OutputFile "error_report.txt"
+
+.EXAMPLE
+    .\extract_log_errors.ps1 -LastNLines 5000
+#>
+
+param(
+    [string]$LogPath = "$env:USERPROFILE\Documents\My Games\FarmingSimulator2025\log.txt",
+    [string]$OutputFile = "",
+    [int]$LastNLines = 0
+)
+
+# Colors for console output
+function Write-ColorOutput {
+    param([string]$Message, [string]$Color = "White")
+    Write-Host $Message -ForegroundColor $Color
+}
+
+function Write-Header {
+    param([string]$Text)
+    Write-ColorOutput "`n$('=' * 60)" "Cyan"
+    Write-ColorOutput $Text "Cyan"
+    Write-ColorOutput "$('=' * 60)" "Cyan"
+}
+
+function Write-SubHeader {
+    param([string]$Text)
+    Write-ColorOutput "`n$Text" "Yellow"
+    Write-ColorOutput ("-" * $Text.Length) "Yellow"
+}
+
+# Check if log file exists
+if (-not (Test-Path $LogPath)) {
+    Write-ColorOutput "Error: Log file not found at: $LogPath" "Red"
+    Write-ColorOutput "Make sure you've run the game at least once." "Yellow"
+    exit 1
+}
+
+Write-Header "MarketDynamics Log Analyzer"
+Write-ColorOutput "Analyzing: $LogPath" "Gray"
+Write-ColorOutput "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" "Gray"
+
+# Read log file
+$logContent = Get-Content $LogPath -Raw
+$lines = $logContent -split "`n"
+
+if ($LastNLines -gt 0 -and $lines.Count -gt $LastNLines) {
+    Write-ColorOutput "Analyzing last $LastNLines lines of $($lines.Count) total" "Gray"
+    $lines = $lines | Select-Object -Last $LastNLines
+}
+
+# Initialize counters and collections
+$stats = @{
+    TotalLines = $lines.Count
+    MarketDynamicsLines = 0
+    Errors = @()
+    Warnings = @()
+    LuaErrors = @()
+    NilAccess = @()
+    XmlErrors = @()
+    LoadSuccess = $false
+    ModVersion = "Unknown"
+}
+
+# Patterns to match
+$patterns = @{
+    # MarketDynamics specific patterns
+    MarketDynamicsLine = 'MDM|FS25_MarketDynamics'
+    ModLoaded = 'v(\d+\.\d+\.\d+)'
+
+    # Error patterns
+    LuaError = 'Error: .+\.lua:\d+'
+    LuaRuntime = 'attempt to (call|index|compare|concatenate|perform arithmetic)'
+    NilValue = "attempt to \w+ (?:a )?nil value"
+    XmlParse = 'XML parse error|Could not load XML'
+    Warning = 'Warning:'
+
+    # Specific MarketDynamics patterns
+    ManagerInit = '(FinanceManager|UsedVehicleManager|VehicleSaleManager)\s+(initialized|loaded)'
+    DialogError = 'Dialog.*(?:nil|error|failed)'
+    EventError = 'Event.*(?:nil|error|failed)'
+}
+
+# Track context for multi-line errors
+$inStackTrace = $false
+$currentError = @()
+
+foreach ($i in 0..($lines.Count - 1)) {
+    $line = $lines[$i]
+
+    # Check if line is MarketDynamics related
+    if ($line -match $patterns.MarketDynamicsLine) {
+        $stats.MarketDynamicsLines++
+
+        # Check for mod version
+        if ($line -match $patterns.ModLoaded) {
+            $stats.ModVersion = $matches[1]
+            $stats.LoadSuccess = $true
+        }
+
+        # Check for Lua errors
+        if ($line -match $patterns.LuaError -or $line -match $patterns.LuaRuntime) {
+            $errorEntry = @{
+                Line = $i + 1
+                Text = $line.Trim()
+                Type = "LuaError"
+            }
+
+            # Capture stack trace if present
+            $stackTrace = @($line)
+            $j = $i + 1
+            while ($j -lt $lines.Count -and $lines[$j] -match '^\s+(at|in|\.lua:\d+)') {
+                $stackTrace += $lines[$j]
+                $j++
+            }
+            $errorEntry.StackTrace = $stackTrace -join "`n"
+            $stats.LuaErrors += $errorEntry
+            $stats.Errors += $errorEntry
+        }
+
+        # Check for nil access
+        if ($line -match $patterns.NilValue) {
+            $errorEntry = @{
+                Line = $i + 1
+                Text = $line.Trim()
+                Type = "NilAccess"
+            }
+            $stats.NilAccess += $errorEntry
+            $stats.Errors += $errorEntry
+        }
+
+        # Check for warnings
+        if ($line -match $patterns.Warning) {
+            $stats.Warnings += @{
+                Line = $i + 1
+                Text = $line.Trim()
+                Type = "Warning"
+            }
+        }
+    }
+
+    # Also check for XML errors that might reference our mod
+    if ($line -match $patterns.XmlParse -and $line -match 'MarketDynamics') {
+        $stats.XmlErrors += @{
+            Line = $i + 1
+            Text = $line.Trim()
+            Type = "XmlError"
+        }
+        $stats.Errors += $stats.XmlErrors[-1]
+    }
+}
+
+# Generate report
+$report = @()
+$report += "=" * 60
+$report += "MarketDynamics Error Report"
+$report += "Generated: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+$report += "=" * 60
+
+$report += "`nSUMMARY"
+$report += "-" * 40
+$report += "Mod Version: $($stats.ModVersion)"
+$report += "Mod Loaded Successfully: $($stats.LoadSuccess)"
+$report += "Total Log Lines: $($stats.TotalLines)"
+$report += "MarketDynamics-Related Lines: $($stats.MarketDynamicsLines)"
+$report += "Errors Found: $($stats.Errors.Count)"
+$report += "Warnings Found: $($stats.Warnings.Count)"
+
+if ($stats.Errors.Count -eq 0 -and $stats.Warnings.Count -eq 0) {
+    $report += "`nNo errors or warnings found - log is clean!"
+    Write-ColorOutput "`nNo errors or warnings found - log is clean!" "Green"
+}
+
+# Detailed error breakdown
+if ($stats.LuaErrors.Count -gt 0) {
+    $report += "`nLUA ERRORS ($($stats.LuaErrors.Count))"
+    $report += "-" * 40
+    foreach ($err in $stats.LuaErrors) {
+        $report += "Line $($err.Line): $($err.Text)"
+        if ($err.StackTrace) {
+            $report += $err.StackTrace
+        }
+        $report += ""
+    }
+
+    Write-SubHeader "LUA ERRORS ($($stats.LuaErrors.Count))"
+    foreach ($err in $stats.LuaErrors | Select-Object -First 5) {
+        Write-ColorOutput "  Line $($err.Line): $($err.Text)" "Red"
+    }
+    if ($stats.LuaErrors.Count -gt 5) {
+        Write-ColorOutput "  ... and $($stats.LuaErrors.Count - 5) more" "Red"
+    }
+}
+
+if ($stats.NilAccess.Count -gt 0) {
+    $report += "`nNIL ACCESS ERRORS ($($stats.NilAccess.Count))"
+    $report += "-" * 40
+    foreach ($err in $stats.NilAccess) {
+        $report += "Line $($err.Line): $($err.Text)"
+    }
+
+    Write-SubHeader "NIL ACCESS ERRORS ($($stats.NilAccess.Count))"
+    foreach ($err in $stats.NilAccess | Select-Object -First 5) {
+        Write-ColorOutput "  Line $($err.Line): $($err.Text)" "Red"
+    }
+    if ($stats.NilAccess.Count -gt 5) {
+        Write-ColorOutput "  ... and $($stats.NilAccess.Count - 5) more" "Red"
+    }
+}
+
+if ($stats.XmlErrors.Count -gt 0) {
+    $report += "`nXML ERRORS ($($stats.XmlErrors.Count))"
+    $report += "-" * 40
+    foreach ($err in $stats.XmlErrors) {
+        $report += "Line $($err.Line): $($err.Text)"
+    }
+
+    Write-SubHeader "XML ERRORS ($($stats.XmlErrors.Count))"
+    foreach ($err in $stats.XmlErrors) {
+        Write-ColorOutput "  Line $($err.Line): $($err.Text)" "Red"
+    }
+}
+
+if ($stats.Warnings.Count -gt 0) {
+    $report += "`nWARNINGS ($($stats.Warnings.Count))"
+    $report += "-" * 40
+    foreach ($warn in $stats.Warnings) {
+        $report += "Line $($warn.Line): $($warn.Text)"
+    }
+
+    Write-SubHeader "WARNINGS ($($stats.Warnings.Count))"
+    foreach ($warn in $stats.Warnings | Select-Object -First 10) {
+        Write-ColorOutput "  Line $($warn.Line): $($warn.Text)" "Yellow"
+    }
+    if ($stats.Warnings.Count -gt 10) {
+        Write-ColorOutput "  ... and $($stats.Warnings.Count - 10) more" "Yellow"
+    }
+}
+
+# Output report
+if ($OutputFile) {
+    $report | Out-File -FilePath $OutputFile -Encoding utf8
+    Write-ColorOutput "`nReport saved to: $OutputFile" "Green"
+} else {
+    Write-Header "END OF REPORT"
+}
+
+# Exit with appropriate code
+if ($stats.Errors.Count -gt 0) {
+    exit 1
+} else {
+    exit 0
+}

--- a/tools/find_global_leaks.js
+++ b/tools/find_global_leaks.js
@@ -1,0 +1,209 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, '..', 'src');
+const outputFile = path.join(__dirname, '..', 'GLOBAL_LEAK_AUDIT.md');
+
+const issues = [];
+let totalFiles = 0;
+
+function isClassDefinition(line) {
+    // Top-level class definitions like "MyClass = {}"
+    return /^[A-Z][a-zA-Z0-9_]*\s*=\s*\{/.test(line);
+}
+
+function isValidGlobal(line) {
+    // Valid patterns that are intentional globals
+    return (
+        /^[A-Z][a-zA-Z0-9_]*\s*=\s*\{/.test(line) ||  // Class definition
+        /^g_[a-zA-Z]/.test(line) ||                    // g_ prefix (intentional global)
+        /^source\(/.test(line) ||                      // source() calls
+        line.includes('self.') ||                       // self references
+        line.includes('spec.') ||                       // spec references
+        line.includes('this.') ||                       // this references
+        /^\s*--/.test(line) ||                         // Comments
+        /^\s*local\s/.test(line) ||                    // local keyword
+        /^\s*\[["'][a-zA-Z_]/.test(line) ||           // Table key assignment
+        /^\s*[A-Z_]+\s*=/.test(line.trim()) &&         // CONSTANT = value (in table def)
+          line.trim().endsWith(',')
+    );
+}
+
+function analyzeLine(line, lineNum, filePath) {
+    const trimmed = line.trim();
+
+    // Skip empty lines, comments, and lines starting with keywords
+    if (!trimmed || trimmed.startsWith('--') || trimmed.startsWith('local ')) {
+        return null;
+    }
+
+    // Look for assignment without local
+    const match = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([^=].*)/);
+    if (match && line.startsWith('    ')) {  // Indented = inside a function
+        const varName = match[1];
+        const value = match[2];
+
+        // Filter out valid patterns
+        if (varName === 'self' || varName === 'spec' || varName === 'this') return null;
+        if (varName.startsWith('g_')) return null;
+        if (isValidGlobal(line)) return null;
+
+        // Check if it's a table field (has dots before)
+        if (line.includes('.') && line.indexOf('.') < line.indexOf('=')) return null;
+
+        // Potential leak!
+        return {
+            file: filePath,
+            line: lineNum,
+            variable: varName,
+            value: value.substring(0, 50),  // Truncate long values
+            code: line
+        };
+    }
+
+    return null;
+}
+
+function analyzeFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+    const fileIssues = [];
+
+    lines.forEach((line, idx) => {
+        const issue = analyzeLine(line, idx + 1, filePath);
+        if (issue) {
+            fileIssues.push(issue);
+        }
+    });
+
+    return fileIssues;
+}
+
+function scanDirectory(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            scanDirectory(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith('.lua')) {
+            totalFiles++;
+            const fileIssues = analyzeFile(fullPath);
+            issues.push(...fileIssues);
+        }
+    }
+}
+
+function categorizeIssue(issue) {
+    const varName = issue.variable;
+
+    // High severity: loop counters, common temp vars
+    if (['i', 'j', 'k', 'count', 'index', 'total', 'sum'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // High: variables used in calculations
+    if (['score', 'result', 'value', 'amount', 'price', 'cost'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // Medium: descriptive names that might be temps
+    if (varName.endsWith('Score') || varName.endsWith('Bonus') ||
+        varName.endsWith('Penalty') || varName.endsWith('Total')) {
+        return 'MEDIUM';
+    }
+
+    // Low: everything else
+    return 'LOW';
+}
+
+function generateReport() {
+    const high = issues.filter(i => categorizeIssue(i) === 'HIGH');
+    const medium = issues.filter(i => categorizeIssue(i) === 'MEDIUM');
+    const low = issues.filter(i => categorizeIssue(i) === 'LOW');
+
+    let report = `# GLOBAL VARIABLE LEAK AUDIT - FS25_UsedPlus\n\n`;
+    report += `**Generated:** ${new Date().toISOString()}\n`;
+    report += `**Total Lua files scanned:** ${totalFiles}\n`;
+    report += `**Potential leaks found:** ${issues.length}\n\n`;
+    report += `## Severity Breakdown\n\n`;
+    report += `- **HIGH:** ${high.length} (immediate fix recommended)\n`;
+    report += `- **MEDIUM:** ${medium.length} (review needed)\n`;
+    report += `- **LOW:** ${low.length} (low priority)\n\n`;
+    report += `---\n\n`;
+
+    function writeSection(title, items) {
+        if (items.length === 0) return '';
+
+        let section = `## ${title}\n\n`;
+
+        // Group by file
+        const byFile = {};
+        items.forEach(issue => {
+            const relPath = issue.file.replace(/\\/g, '/').split('/src/')[1];
+            if (!byFile[relPath]) byFile[relPath] = [];
+            byFile[relPath].push(issue);
+        });
+
+        Object.keys(byFile).sort().forEach(file => {
+            section += `### \`src/${file}\`\n\n`;
+
+            byFile[file].forEach(issue => {
+                section += `**Line ${issue.line}:** \`${issue.variable}\`\n`;
+                section += `\`\`\`lua\n${issue.code.trim()}\n\`\`\`\n`;
+                section += `**Recommendation:** Add \`local\` keyword before \`${issue.variable}\`\n\n`;
+            });
+
+            section += `---\n\n`;
+        });
+
+        return section;
+    }
+
+    report += writeSection('HIGH SEVERITY', high);
+    report += writeSection('MEDIUM SEVERITY', medium);
+    report += writeSection('LOW SEVERITY', low);
+
+    report += `## Summary & Recommendations\n\n`;
+    report += `### Pattern Analysis\n\n`;
+
+    const varCounts = {};
+    issues.forEach(i => {
+        varCounts[i.variable] = (varCounts[i.variable] || 0) + 1;
+    });
+
+    const sorted = Object.entries(varCounts).sort((a, b) => b[1] - a[1]);
+    report += `**Most common leaked variable names:**\n\n`;
+    sorted.slice(0, 10).forEach(([name, count]) => {
+        report += `- \`${name}\`: ${count} occurrences\n`;
+    });
+
+    report += `\n### General Recommendations\n\n`;
+    report += `1. **Add \`local\` keyword** to all variable assignments inside functions\n`;
+    report += `2. **For loop counters** like \`i\`, \`j\`, \`count\`: Always use \`local for i = 1, n do\`\n`;
+    report += `3. **For calculations**: Declare temps as \`local score = 0\` at function start\n`;
+    report += `4. **Review HIGH severity** items first - these are most likely to cause bugs\n`;
+    report += `5. **Test thoroughly** after fixes - global leaks can have subtle cross-module effects\n\n`;
+
+    report += `### Known Safe Patterns (Excluded)\n\n`;
+    report += `- Class definitions: \`MyClass = {}\` at top level\n`;
+    report += `- Intentional globals: \`g_myGlobal = ...\`\n`;
+    report += `- Self/spec references: \`self.field = ...\`, \`spec.field = ...\`\n`;
+    report += `- Table field assignments: \`myTable.field = ...\`\n`;
+    report += `- Constants in table definitions: \`CONSTANT_NAME = value,\`\n\n`;
+
+    return report;
+}
+
+// Run the scan
+console.log('Scanning for global variable leaks...');
+scanDirectory(srcDir);
+
+const report = generateReport();
+fs.writeFileSync(outputFile, report);
+
+console.log(`\nAudit complete!`);
+console.log(`- Files scanned: ${totalFiles}`);
+console.log(`- Potential leaks: ${issues.length}`);
+console.log(`- Report written to: ${outputFile}`);

--- a/tools/find_global_leaks_v2.js
+++ b/tools/find_global_leaks_v2.js
@@ -1,0 +1,256 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, '..', 'src');
+const outputFile = path.join(__dirname, '..', 'GLOBAL_LEAK_AUDIT.md');
+
+const issues = [];
+let totalFiles = 0;
+
+function analyzeFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+    const fileIssues = [];
+
+    // Track local variables per function scope
+    let inFunction = false;
+    let functionDepth = 0;
+    let localVars = new Set();
+    let linesBefore = [];
+
+    lines.forEach((line, idx) => {
+        const trimmed = line.trim();
+        const lineNum = idx + 1;
+
+        // Track function scope
+        if (/^function\s/.test(trimmed) || /\sfunction\s*\(/.test(trimmed)) {
+            inFunction = true;
+            functionDepth = 0;
+            localVars = new Set();
+        }
+
+        // Track 'end' keywords (rough depth tracking)
+        const endMatches = line.match(/\bend\b/g);
+        if (endMatches) {
+            functionDepth -= endMatches.length;
+            if (functionDepth <= 0) {
+                inFunction = false;
+                localVars.clear();
+            }
+        }
+
+        // Track 'do', 'then', 'repeat' keywords (increase depth)
+        if (/\b(do|then|repeat)\b/.test(line)) {
+            functionDepth++;
+        }
+
+        // Collect local variable declarations
+        const localMatch = trimmed.match(/^local\s+([a-zA-Z_][a-zA-Z0-9_]*)/);
+        if (localMatch) {
+            localVars.add(localMatch[1]);
+        }
+
+        // Look for assignments without 'local' inside functions
+        if (inFunction && line.startsWith('    ')) {  // Indented
+            // Skip comments
+            if (trimmed.startsWith('--')) {
+                linesBefore.push(line);
+                return;
+            }
+
+            // Match variable assignment (not table field, not self/spec)
+            const match = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([^=].*)/);
+            if (match) {
+                const varName = match[1];
+                const value = match[2];
+
+                // Filter out safe patterns
+                if (varName === 'self' || varName === 'spec' || varName === 'this') {
+                    linesBefore.push(line);
+                    return;
+                }
+                if (varName.startsWith('g_')) {
+                    linesBefore.push(line);
+                    return;
+                }
+                if (localVars.has(varName)) {
+                    // This is modifying a local variable (safe!)
+                    linesBefore.push(line);
+                    return;
+                }
+                if (line.includes('.') && line.indexOf('.') < line.indexOf('=')) {
+                    // Table field assignment like foo.bar = ...
+                    linesBefore.push(line);
+                    return;
+                }
+                if (trimmed.endsWith(',') || trimmed.endsWith('},')) {
+                    // Part of table initialization
+                    linesBefore.push(line);
+                    return;
+                }
+
+                // POTENTIAL LEAK!
+                const context = [
+                    ...linesBefore.slice(-2),
+                    line,
+                    ...lines.slice(idx + 1, idx + 3)
+                ].join('\n');
+
+                fileIssues.push({
+                    file: filePath,
+                    line: lineNum,
+                    variable: varName,
+                    value: value.substring(0, 50),
+                    code: line.trim(),
+                    context: context
+                });
+            }
+        }
+
+        // Keep last 3 lines for context
+        linesBefore.push(line);
+        if (linesBefore.length > 3) {
+            linesBefore.shift();
+        }
+    });
+
+    return fileIssues;
+}
+
+function scanDirectory(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            scanDirectory(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith('.lua')) {
+            totalFiles++;
+            const fileIssues = analyzeFile(fullPath);
+            issues.push(...fileIssues);
+        }
+    }
+}
+
+function categorizeIssue(issue) {
+    const varName = issue.variable;
+
+    // High severity: loop counters, common temp vars
+    if (['i', 'j', 'k', 'count', 'index', 'total', 'sum', 'result'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // High: variables used in calculations
+    if (['score', 'value', 'amount', 'price', 'cost', 'balance'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // Medium: descriptive names that might be temps
+    if (varName.endsWith('Score') || varName.endsWith('Bonus') ||
+        varName.endsWith('Penalty') || varName.endsWith('Total') ||
+        varName.endsWith('Index') || varName.endsWith('Count')) {
+        return 'MEDIUM';
+    }
+
+    // Low: everything else
+    return 'LOW';
+}
+
+function generateReport() {
+    const high = issues.filter(i => categorizeIssue(i) === 'HIGH');
+    const medium = issues.filter(i => categorizeIssue(i) === 'MEDIUM');
+    const low = issues.filter(i => categorizeIssue(i) === 'LOW');
+
+    let report = `# GLOBAL VARIABLE LEAK AUDIT - FS25_UsedPlus\n\n`;
+    report += `**Generated:** ${new Date().toISOString()}\n`;
+    report += `**Total Lua files scanned:** ${totalFiles}\n`;
+    report += `**Potential leaks found:** ${issues.length}\n\n`;
+    report += `## Severity Breakdown\n\n`;
+    report += `- **HIGH:** ${high.length} (immediate fix recommended)\n`;
+    report += `- **MEDIUM:** ${medium.length} (review needed)\n`;
+    report += `- **LOW:** ${low.length} (low priority)\n\n`;
+    report += `---\n\n`;
+
+    function writeSection(title, items) {
+        if (items.length === 0) return '';
+
+        let section = `## ${title}\n\n`;
+
+        // Group by file
+        const byFile = {};
+        items.forEach(issue => {
+            const relPath = issue.file.replace(/\\/g, '/').split('/src/')[1];
+            if (!byFile[relPath]) byFile[relPath] = [];
+            byFile[relPath].push(issue);
+        });
+
+        Object.keys(byFile).sort().forEach(file => {
+            section += `### \`src/${file}\`\n\n`;
+
+            byFile[file].forEach(issue => {
+                section += `**Line ${issue.line}:** \`${issue.variable} = ${issue.value}\`\n\n`;
+                section += `\`\`\`lua\n${issue.context}\n\`\`\`\n\n`;
+                section += `**Issue:** Variable \`${issue.variable}\` is assigned without \`local\` keyword.\n`;
+                section += `**Fix:** Add \`local ${issue.variable}\` before first use, or add \`local\` to this line.\n\n`;
+                section += `---\n\n`;
+            });
+        });
+
+        return section;
+    }
+
+    report += writeSection('HIGH SEVERITY LEAKS', high);
+    report += writeSection('MEDIUM SEVERITY LEAKS', medium);
+    report += writeSection('LOW SEVERITY LEAKS', low);
+
+    report += `## Summary & Recommendations\n\n`;
+    report += `### Pattern Analysis\n\n`;
+
+    const varCounts = {};
+    issues.forEach(i => {
+        varCounts[i.variable] = (varCounts[i.variable] || 0) + 1;
+    });
+
+    const sorted = Object.entries(varCounts).sort((a, b) => b[1] - a[1]);
+    report += `**Most common leaked variable names:**\n\n`;
+    sorted.slice(0, 15).forEach(([name, count]) => {
+        report += `- \`${name}\`: ${count} occurrences\n`;
+    });
+
+    report += `\n### General Recommendations\n\n`;
+    report += `1. **Add \`local\` keyword** to all variable declarations\n`;
+    report += `2. **For loop counters**: Use \`for i = 1, n do\` (implicit local) or \`local i; for i = ...\`\n`;
+    report += `3. **For calculations**: Declare temps as \`local score = 0\` at function start\n`;
+    report += `4. **Review HIGH severity** items first - these are most likely to cause bugs\n`;
+    report += `5. **Test thoroughly** after fixes - global leaks can have subtle effects\n\n`;
+
+    report += `### Impact of Global Leaks\n\n`;
+    report += `Global variables in Lua can cause:\n`;
+    report += `- **Cross-contamination**: Variable values leak between function calls\n`;
+    report += `- **Multiplayer bugs**: Server/client state corruption\n`;
+    report += `- **Hard-to-debug issues**: Values mysteriously changing\n`;
+    report += `- **Performance**: Global table lookups are slower than locals\n\n`;
+
+    report += `### Known Safe Patterns (Excluded from Report)\n\n`;
+    report += `- Class definitions: \`MyClass = {}\` at top level\n`;
+    report += `- Intentional globals: \`g_myGlobal = ...\`\n`;
+    report += `- Self/spec references: \`self.field = ...\`, \`spec.field = ...\`\n`;
+    report += `- Table field assignments: \`myTable.field = ...\`\n`;
+    report += `- Local variable modifications: \`score = score + 10\` (if \`local score\` was declared earlier)\n`;
+    report += `- Table initializations: Lines ending with \`,\` or \`},\`\n\n`;
+
+    return report;
+}
+
+// Run the scan
+console.log('Scanning for global variable leaks (v2 - scope-aware)...');
+scanDirectory(srcDir);
+
+const report = generateReport();
+fs.writeFileSync(outputFile, report);
+
+console.log(`\nAudit complete!`);
+console.log(`- Files scanned: ${totalFiles}`);
+console.log(`- Potential leaks: ${issues.length}`);
+console.log(`- Report written to: ${outputFile}`);

--- a/tools/find_global_leaks_v2.js
+++ b/tools/find_global_leaks_v2.js
@@ -83,7 +83,8 @@ function analyzeFile(filePath) {
                     linesBefore.push(line);
                     return;
                 }
-                if (trimmed.endsWith(',') || trimmed.endsWith('},')) {
+                const strippedComment = trimmed.replace(/--.*$/, '').trim();
+                if (strippedComment.endsWith(',') || strippedComment.endsWith('},') || strippedComment.endsWith('}')) {
                     // Part of table initialization
                     linesBefore.push(line);
                     return;
@@ -162,7 +163,7 @@ function generateReport() {
     const medium = issues.filter(i => categorizeIssue(i) === 'MEDIUM');
     const low = issues.filter(i => categorizeIssue(i) === 'LOW');
 
-    let report = `# GLOBAL VARIABLE LEAK AUDIT - FS25_UsedPlus\n\n`;
+    let report = `# GLOBAL VARIABLE LEAK AUDIT - FS25_MarketDynamics\n\n`;
     report += `**Generated:** ${new Date().toISOString()}\n`;
     report += `**Total Lua files scanned:** ${totalFiles}\n`;
     report += `**Potential leaks found:** ${issues.length}\n\n`;

--- a/tools/find_unused.js
+++ b/tools/find_unused.js
@@ -1,0 +1,1065 @@
+#!/usr/bin/env node
+/**
+ * FS25_UsedPlus - Find Unused Code Scanner
+ *
+ * Scans the codebase for potentially orphaned:
+ * - Lua files not registered in modDesc.xml
+ * - Dialog files (.lua + .xml) not called by DialogLoader or getInstance
+ * - Functions defined but never referenced elsewhere
+ *
+ * Usage:
+ *   node find_unused.js [--verbose] [--check-functions]
+ *
+ * Author: Claude & Samantha
+ * Version: 1.3.0 - Added vanilla hooks, event subscriptions, vehicle metrics, malfunctions
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ANSI colors
+const colors = {
+    red: '\x1b[91m',
+    green: '\x1b[92m',
+    yellow: '\x1b[93m',
+    blue: '\x1b[94m',
+    cyan: '\x1b[96m',
+    reset: '\x1b[0m',
+    bold: '\x1b[1m'
+};
+
+/**
+ * Find the mod root directory (where modDesc.xml lives)
+ */
+function getModRoot() {
+    let dir = __dirname;
+
+    // Go up from tools/ to mod root
+    const parentDir = path.dirname(dir);
+    if (fs.existsSync(path.join(parentDir, 'modDesc.xml'))) {
+        return parentDir;
+    }
+
+    // Try current directory
+    if (fs.existsSync('modDesc.xml')) {
+        return process.cwd();
+    }
+
+    console.error(`${colors.red}Error: Cannot find modDesc.xml${colors.reset}`);
+    process.exit(1);
+}
+
+/**
+ * Parse modDesc.xml and get registered source files
+ */
+function parseModDescSources(modRoot) {
+    const modDescPath = path.join(modRoot, 'modDesc.xml');
+    const content = fs.readFileSync(modDescPath, 'utf8');
+
+    const registered = new Set();
+    const regex = /sourceFile\s+filename="([^"]+)"/g;
+    let match;
+
+    while ((match = regex.exec(content)) !== null) {
+        registered.add(match[1].replace(/\//g, path.sep));
+    }
+
+    return registered;
+}
+
+/**
+ * Recursively find all files matching a pattern
+ */
+function findFiles(dir, pattern, results = []) {
+    if (!fs.existsSync(dir)) return results;
+
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+        const filePath = path.join(dir, file);
+        const stat = fs.statSync(filePath);
+
+        if (stat.isDirectory()) {
+            findFiles(filePath, pattern, results);
+        } else if (pattern.test(file)) {
+            results.push(filePath);
+        }
+    }
+
+    return results;
+}
+
+/**
+ * Find all Lua files in src/
+ */
+function findAllLuaFiles(modRoot) {
+    const srcDir = path.join(modRoot, 'src');
+    const files = findFiles(srcDir, /\.lua$/);
+
+    return new Set(files.map(f => path.relative(modRoot, f)));
+}
+
+/**
+ * Find all dialog files (paired .lua and .xml)
+ */
+function findAllDialogs(modRoot) {
+    const dialogs = {};
+
+    // Find Lua dialog files in src/gui
+    const guiDir = path.join(modRoot, 'src', 'gui');
+    if (fs.existsSync(guiDir)) {
+        const luaFiles = findFiles(guiDir, /Dialog\.lua$/);
+        for (const file of luaFiles) {
+            const name = path.basename(file, '.lua');
+            dialogs[name] = { lua: file, xml: null };
+        }
+    }
+
+    // Find XML dialog files in gui/
+    const xmlDir = path.join(modRoot, 'gui');
+    if (fs.existsSync(xmlDir)) {
+        const xmlFiles = findFiles(xmlDir, /Dialog\.xml$/);
+        for (const file of xmlFiles) {
+            const name = path.basename(file, '.xml');
+            if (dialogs[name]) {
+                dialogs[name].xml = file;
+            } else {
+                dialogs[name] = { lua: null, xml: file };
+            }
+        }
+    }
+
+    return dialogs;
+}
+
+/**
+ * Search for references to a dialog in all Lua files
+ * v1.0.1: Now searches src/, vehicles/, placeables/ directories
+ */
+function searchDialogReferences(modRoot, dialogName) {
+    const patterns = [
+        new RegExp(`DialogLoader\\.show\\s*\\(\\s*["']?${dialogName}["']?`),
+        new RegExp(`DialogLoader\\.register\\s*\\(\\s*["']${dialogName}["']`),
+        new RegExp(`${dialogName}\\.getInstance`),
+        new RegExp(`${dialogName}\\.show`),
+        new RegExp(`${dialogName}\\.new`),
+        new RegExp(`g_gui:loadGui\\s*\\([^,]+,\\s*["']?${dialogName}["']?`),
+        new RegExp(`g_gui:showDialog\\s*\\(\\s*["']${dialogName}["']`),
+        new RegExp(`showDialog\\s*\\(\\s*["']?${dialogName}["']?`)
+    ];
+
+    // Search multiple directories - v1.0.1
+    const searchDirs = ['src', 'vehicles', 'placeables'];
+    let luaFiles = [];
+    for (const dir of searchDirs) {
+        const dirPath = path.join(modRoot, dir);
+        if (fs.existsSync(dirPath)) {
+            luaFiles = luaFiles.concat(findFiles(dirPath, /\.lua$/));
+        }
+    }
+
+    const references = [];
+
+    for (const file of luaFiles) {
+        // Skip the dialog's own file
+        if (path.basename(file, '.lua') === dialogName) continue;
+
+        try {
+            const content = fs.readFileSync(file, 'utf8');
+            for (const pattern of patterns) {
+                if (pattern.test(content)) {
+                    references.push(path.relative(modRoot, file));
+                    break;
+                }
+            }
+        } catch (e) {
+            // Ignore read errors
+        }
+    }
+
+    return references;
+}
+
+/**
+ * Count lines of code in a file (excluding blank lines and comments)
+ */
+function countLinesOfCode(filePath) {
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const lines = content.split('\n');
+        let codeLines = 0;
+        let commentLines = 0;
+        let blankLines = 0;
+        let inBlockComment = false;
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+
+            // Blank line
+            if (trimmed === '') {
+                blankLines++;
+                continue;
+            }
+
+            // Block comment handling (Lua uses --[[ ]])
+            if (inBlockComment) {
+                commentLines++;
+                if (trimmed.includes(']]')) {
+                    inBlockComment = false;
+                }
+                continue;
+            }
+
+            // Start of block comment
+            if (trimmed.startsWith('--[[')) {
+                commentLines++;
+                if (!trimmed.includes(']]')) {
+                    inBlockComment = true;
+                }
+                continue;
+            }
+
+            // Single line comment
+            if (trimmed.startsWith('--')) {
+                commentLines++;
+                continue;
+            }
+
+            codeLines++;
+        }
+
+        return { total: lines.length, code: codeLines, comments: commentLines, blank: blankLines };
+    } catch (e) {
+        return { total: 0, code: 0, comments: 0, blank: 0 };
+    }
+}
+
+/**
+ * Get file size in a human-readable format
+ */
+function formatFileSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+}
+
+/**
+ * Gather codebase statistics
+ */
+function gatherStatistics(modRoot) {
+    const stats = {
+        lua: {
+            total: 0,
+            byCategory: {},
+            totalLines: 0,
+            codeLines: 0,
+            commentLines: 0,
+            blankLines: 0,
+            totalSize: 0,
+            largestFiles: []
+        },
+        xml: {
+            total: 0,
+            gui: 0,
+            translations: 0,
+            other: 0,
+            totalSize: 0
+        },
+        dialogs: 0,
+        events: 0,
+        managers: 0,
+        extensions: 0,
+        specializations: 0,
+        utils: 0
+    };
+
+    // Categories to track
+    const categories = {
+        'src/gui': 'GUI Screens',
+        'src/gui/financepanels': 'Finance Panels',
+        'src/events': 'Network Events',
+        'src/managers': 'Managers',
+        'src/managers/usedvehicle': 'Used Vehicle Modules',
+        'src/extensions': 'Extensions',
+        'src/specializations': 'Specializations',
+        'src/specializations/maintenance': 'Maintenance Modules',
+        'src/utils': 'Utilities',
+        'src/data': 'Data Classes',
+        'src/settings': 'Settings',
+        'src/core': 'Core',
+        'vehicles': 'Vehicles',
+        'placeables': 'Placeables'
+    };
+
+    // Initialize categories
+    for (const cat of Object.values(categories)) {
+        stats.lua.byCategory[cat] = { files: 0, lines: 0 };
+    }
+    stats.lua.byCategory['Other'] = { files: 0, lines: 0 };
+
+    // Scan all Lua files
+    const luaDirs = ['src', 'vehicles', 'placeables'];
+    const allLuaFiles = [];
+
+    for (const dir of luaDirs) {
+        const dirPath = path.join(modRoot, dir);
+        if (fs.existsSync(dirPath)) {
+            const files = findFiles(dirPath, /\.lua$/);
+            allLuaFiles.push(...files);
+        }
+    }
+
+    for (const file of allLuaFiles) {
+        const relPath = path.relative(modRoot, file).replace(/\\/g, '/');
+        const fileStat = fs.statSync(file);
+        const lineStats = countLinesOfCode(file);
+
+        stats.lua.total++;
+        stats.lua.totalLines += lineStats.total;
+        stats.lua.codeLines += lineStats.code;
+        stats.lua.commentLines += lineStats.comments;
+        stats.lua.blankLines += lineStats.blank;
+        stats.lua.totalSize += fileStat.size;
+
+        // Track largest files
+        stats.lua.largestFiles.push({
+            name: path.basename(file),
+            path: relPath,
+            lines: lineStats.total,
+            code: lineStats.code,
+            size: fileStat.size
+        });
+
+        // Categorize
+        let categorized = false;
+        for (const [prefix, catName] of Object.entries(categories)) {
+            if (relPath.startsWith(prefix)) {
+                // Use most specific match
+                const currentDepth = prefix.split('/').length;
+                let foundBetter = false;
+                for (const [otherPrefix, otherCat] of Object.entries(categories)) {
+                    if (relPath.startsWith(otherPrefix) &&
+                        otherPrefix.split('/').length > currentDepth) {
+                        foundBetter = true;
+                        break;
+                    }
+                }
+                if (!foundBetter) {
+                    stats.lua.byCategory[catName].files++;
+                    stats.lua.byCategory[catName].lines += lineStats.code;
+                    categorized = true;
+                    break;
+                }
+            }
+        }
+        if (!categorized) {
+            stats.lua.byCategory['Other'].files++;
+            stats.lua.byCategory['Other'].lines += lineStats.code;
+        }
+
+        // Count specific types
+        const fileName = path.basename(file);
+        if (fileName.endsWith('Dialog.lua')) stats.dialogs++;
+        if (fileName.endsWith('Event.lua') || fileName.endsWith('Events.lua')) stats.events++;
+        if (fileName.endsWith('Manager.lua')) stats.managers++;
+        if (fileName.endsWith('Extension.lua')) stats.extensions++;
+    }
+
+    // Sort largest files
+    stats.lua.largestFiles.sort((a, b) => b.lines - a.lines);
+    stats.lua.largestFiles = stats.lua.largestFiles.slice(0, 10);
+
+    // Count XML files
+    const xmlDirs = ['gui', 'translations'];
+    for (const dir of xmlDirs) {
+        const dirPath = path.join(modRoot, dir);
+        if (fs.existsSync(dirPath)) {
+            const files = findFiles(dirPath, /\.xml$/);
+            for (const file of files) {
+                const fileStat = fs.statSync(file);
+                stats.xml.total++;
+                stats.xml.totalSize += fileStat.size;
+
+                if (dir === 'gui') stats.xml.gui++;
+                else if (dir === 'translations') stats.xml.translations++;
+                else stats.xml.other++;
+            }
+        }
+    }
+
+    return stats;
+}
+
+/**
+ * Print codebase statistics
+ */
+function printStatistics(stats) {
+    console.log(`\n${colors.bold}${colors.blue}=== Codebase Statistics ===${colors.reset}\n`);
+
+    // Overview
+    console.log(`${colors.bold}Overview:${colors.reset}`);
+    console.log(`  Lua Files:        ${stats.lua.total}`);
+    console.log(`  XML Files:        ${stats.xml.total} (${stats.xml.gui} GUI, ${stats.xml.translations} translations)`);
+    console.log(`  Total Size:       ${formatFileSize(stats.lua.totalSize + stats.xml.totalSize)}`);
+    console.log('');
+
+    // Lines of code
+    console.log(`${colors.bold}Lines of Code (Lua):${colors.reset}`);
+    console.log(`  Total Lines:      ${stats.lua.totalLines.toLocaleString()}`);
+    console.log(`  Code:             ${stats.lua.codeLines.toLocaleString()} (${Math.round(stats.lua.codeLines / stats.lua.totalLines * 100)}%)`);
+    console.log(`  Comments:         ${stats.lua.commentLines.toLocaleString()} (${Math.round(stats.lua.commentLines / stats.lua.totalLines * 100)}%)`);
+    console.log(`  Blank:            ${stats.lua.blankLines.toLocaleString()} (${Math.round(stats.lua.blankLines / stats.lua.totalLines * 100)}%)`);
+    console.log('');
+
+    // Component counts
+    console.log(`${colors.bold}Components:${colors.reset}`);
+    console.log(`  Dialogs:          ${stats.dialogs}`);
+    console.log(`  Events:           ${stats.events}`);
+    console.log(`  Managers:         ${stats.managers}`);
+    console.log(`  Extensions:       ${stats.extensions}`);
+    console.log('');
+
+    // Files by category
+    console.log(`${colors.bold}Files by Category:${colors.reset}`);
+    const sortedCategories = Object.entries(stats.lua.byCategory)
+        .filter(([_, data]) => data.files > 0)
+        .sort((a, b) => b[1].lines - a[1].lines);
+
+    for (const [category, data] of sortedCategories) {
+        const pct = Math.round(data.lines / stats.lua.codeLines * 100);
+        console.log(`  ${category.padEnd(22)} ${String(data.files).padStart(3)} files  ${String(data.lines.toLocaleString()).padStart(7)} lines (${pct}%)`);
+    }
+    console.log('');
+
+    // Largest files
+    console.log(`${colors.bold}Top 10 Largest Files:${colors.reset}`);
+    for (let i = 0; i < stats.lua.largestFiles.length; i++) {
+        const file = stats.lua.largestFiles[i];
+        console.log(`  ${String(i + 1).padStart(2)}. ${file.name.padEnd(40)} ${String(file.lines).padStart(5)} lines  ${formatFileSize(file.size).padStart(8)}`);
+    }
+}
+
+/**
+ * Gather mod-specific information from modDesc.xml and code
+ */
+function gatherModInfo(modRoot) {
+    const modInfo = {
+        name: 'Unknown',
+        version: 'Unknown',
+        author: 'Unknown',
+        title: 'Unknown',
+        description: '',
+        multiplayer: false,
+        translations: [],
+        inputActions: [],
+        storeItems: [],
+        specializations: {
+            vehicle: [],
+            placeable: []
+        },
+        vehicleTypes: [],
+        placeableTypes: [],
+        features: [],
+        crossModCompat: [],
+        settings: []
+    };
+
+    // Parse modDesc.xml
+    const modDescPath = path.join(modRoot, 'modDesc.xml');
+    if (fs.existsSync(modDescPath)) {
+        const content = fs.readFileSync(modDescPath, 'utf8');
+
+        // Basic info
+        const versionMatch = content.match(/<version>([^<]+)<\/version>/);
+        if (versionMatch) modInfo.version = versionMatch[1];
+
+        const authorMatch = content.match(/<author>([^<]+)<\/author>/);
+        if (authorMatch) modInfo.author = authorMatch[1];
+
+        const titleMatch = content.match(/<title>\s*<en>([^<]+)<\/en>/);
+        if (titleMatch) modInfo.title = titleMatch[1].replace(/&amp;/g, '&');
+
+        // Multiplayer support
+        modInfo.multiplayer = content.includes('multiplayer supported="true"');
+
+        // Input actions
+        const actionRegex = /<action name="([^"]+)"/g;
+        let actionMatch;
+        while ((actionMatch = actionRegex.exec(content)) !== null) {
+            modInfo.inputActions.push(actionMatch[1]);
+        }
+
+        // Store items
+        const storeRegex = /<storeItem xmlFilename="([^"]+)"/g;
+        let storeMatch;
+        while ((storeMatch = storeRegex.exec(content)) !== null) {
+            modInfo.storeItems.push(storeMatch[1]);
+        }
+
+        // Vehicle specializations
+        const vehSpecRegex = /<specializations>\s*([\s\S]*?)<\/specializations>/;
+        const vehSpecBlock = content.match(vehSpecRegex);
+        if (vehSpecBlock) {
+            const specRegex = /<specialization name="([^"]+)"/g;
+            let specMatch;
+            while ((specMatch = specRegex.exec(vehSpecBlock[1])) !== null) {
+                modInfo.specializations.vehicle.push(specMatch[1]);
+            }
+        }
+
+        // Placeable specializations
+        const placeSpecRegex = /<placeableSpecializations>\s*([\s\S]*?)<\/placeableSpecializations>/;
+        const placeSpecBlock = content.match(placeSpecRegex);
+        if (placeSpecBlock) {
+            const specRegex = /<specialization name="([^"]+)"/g;
+            let specMatch;
+            while ((specMatch = specRegex.exec(placeSpecBlock[1])) !== null) {
+                modInfo.specializations.placeable.push(specMatch[1]);
+            }
+        }
+
+        // Vehicle types
+        const vehTypeRegex = /<type name="([^"]+)"/g;
+        let vehTypeMatch;
+        while ((vehTypeMatch = vehTypeRegex.exec(content)) !== null) {
+            if (!modInfo.vehicleTypes.includes(vehTypeMatch[1])) {
+                modInfo.vehicleTypes.push(vehTypeMatch[1]);
+            }
+        }
+    }
+
+    // Count translations
+    const transDir = path.join(modRoot, 'translations');
+    if (fs.existsSync(transDir)) {
+        const transFiles = fs.readdirSync(transDir).filter(f => f.endsWith('.xml'));
+        for (const file of transFiles) {
+            const langMatch = file.match(/translation_(\w+)\.xml/);
+            if (langMatch) {
+                modInfo.translations.push(langMatch[1].toUpperCase());
+            }
+        }
+    }
+
+    // Detect features from code patterns
+    const featurePatterns = [
+        { pattern: /FinanceManager|FinanceDeal/g, feature: 'Vehicle/Equipment Financing', icon: '💰' },
+        { pattern: /LeaseDeal|LeaseVehicle/g, feature: 'Vehicle Leasing', icon: '📋' },
+        { pattern: /LandLeaseDeal|LandLeaseEvent/g, feature: 'Land Leasing', icon: '🏞️' },
+        { pattern: /CreditSystem|CreditScore/g, feature: 'Dynamic Credit Scoring (300-850)', icon: '📊' },
+        { pattern: /TakeLoanDialog|TakeLoanEvent/g, feature: 'Collateral-Based Cash Loans', icon: '🏦' },
+        { pattern: /UsedVehicleManager|UsedVehicleSearch/g, feature: 'Used Vehicle Marketplace', icon: '🚜' },
+        { pattern: /VehicleSaleManager|VehicleSaleListing/g, feature: 'Agent-Based Vehicle Sales', icon: '🏷️' },
+        { pattern: /NegotiationDialog|SellerResponseDialog/g, feature: 'Price Negotiation System', icon: '🤝' },
+        { pattern: /InspectionReport|VehicleInspection/g, feature: 'Vehicle Inspection Reports', icon: '🔍' },
+        { pattern: /RepairDialog|RepairVehicleEvent/g, feature: 'Partial Repair System (1-100%)', icon: '🔧' },
+        { pattern: /TiresDialog|MaintenanceTires/g, feature: 'Tire Replacement System', icon: '⚙️' },
+        { pattern: /FluidsDialog|MaintenanceFluids/g, feature: 'Fluid Service (Oil/Hydraulic)', icon: '🛢️' },
+        { pattern: /FieldServiceKit/g, feature: 'Field Service Kit (Roadside Repairs)', icon: '🧰' },
+        { pattern: /OBDScanner|DiagnosisData/g, feature: 'OBD Scanner Diagnostics', icon: '📟' },
+        { pattern: /MaintenanceReliability|MaintenanceEngine/g, feature: 'Component Reliability System', icon: '⚡' },
+        { pattern: /TradeInCalculations|tradeIn/gi, feature: 'Trade-In System', icon: '🔄' },
+        { pattern: /DepreciationCalculations/g, feature: 'Realistic Depreciation', icon: '📉' },
+        { pattern: /DifficultyScalingManager/g, feature: 'Difficulty-Based Pricing', icon: '⚖️' },
+        { pattern: /BankInterestManager/g, feature: 'Bank Interest on Cash', icon: '💵' },
+        { pattern: /PaymentTracker|PaymentHistory/g, feature: 'Payment History Tracking', icon: '📅' },
+        { pattern: /RepossessionDialog/g, feature: 'Vehicle Repossession System', icon: '🚨' },
+        { pattern: /FinanceManagerFrame/g, feature: 'ESC Menu Finance Manager', icon: '📱' },
+        { pattern: /FinancialDashboard/g, feature: 'Financial Dashboard', icon: '📈' }
+    ];
+
+    // Detect cross-mod compatibility
+    const crossModPatterns = [
+        { pattern: /RVB|RealisticVehicleBreakdown/gi, mod: 'FS25_RealisticVehicleBreakdown (RVB)', icon: '🔗' },
+        { pattern: /UYT|UsedYourTool/gi, mod: 'FS25_UsedYourTool (UYT)', icon: '🔗' },
+        { pattern: /ModCompatibility/g, mod: 'Generic Mod Compatibility Layer', icon: '🔌' }
+    ];
+
+    // Scan source files for features
+    const srcDir = path.join(modRoot, 'src');
+    if (fs.existsSync(srcDir)) {
+        const luaFiles = findFiles(srcDir, /\.lua$/);
+        const allContent = luaFiles.map(f => {
+            try { return fs.readFileSync(f, 'utf8'); }
+            catch (e) { return ''; }
+        }).join('\n');
+
+        // Detect features
+        for (const fp of featurePatterns) {
+            if (fp.pattern.test(allContent)) {
+                modInfo.features.push({ name: fp.feature, icon: fp.icon });
+            }
+            fp.pattern.lastIndex = 0; // Reset regex
+        }
+
+        // Detect cross-mod compatibility
+        for (const cm of crossModPatterns) {
+            if (cm.pattern.test(allContent)) {
+                modInfo.crossModCompat.push({ name: cm.mod, icon: cm.icon });
+            }
+            cm.pattern.lastIndex = 0;
+        }
+    }
+
+    // Count settings from UsedPlusSettings
+    const settingsPath = path.join(modRoot, 'src', 'settings', 'UsedPlusSettings.lua');
+    if (fs.existsSync(settingsPath)) {
+        const settingsContent = fs.readFileSync(settingsPath, 'utf8');
+        const settingRegex = /["'](\w+)["']\s*[=:]/g;
+        const defaultsMatch = settingsContent.match(/DEFAULTS\s*=\s*\{([\s\S]*?)\}/);
+        if (defaultsMatch) {
+            let settingMatch;
+            while ((settingMatch = settingRegex.exec(defaultsMatch[1])) !== null) {
+                if (!['true', 'false', 'nil'].includes(settingMatch[1])) {
+                    modInfo.settings.push(settingMatch[1]);
+                }
+            }
+        }
+    }
+
+    // Scan for console commands
+    modInfo.consoleCommands = [];
+    const mainPath = path.join(modRoot, 'src', 'main.lua');
+    if (fs.existsSync(mainPath)) {
+        const mainContent = fs.readFileSync(mainPath, 'utf8');
+        const cmdRegex = /addConsoleCommand\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"/g;
+        let cmdMatch;
+        while ((cmdMatch = cmdRegex.exec(mainContent)) !== null) {
+            modInfo.consoleCommands.push({
+                name: cmdMatch[1],
+                description: cmdMatch[2]
+            });
+        }
+    }
+
+    // Scan for vehicle metrics tracked (maintenance system)
+    modInfo.vehicleMetrics = [];
+    modInfo.malfunctions = [];
+
+    // Gather all maintenance-related content from main spec and modules
+    let maintContent = '';
+    const maintenancePath = path.join(modRoot, 'src', 'specializations', 'UsedPlusMaintenance.lua');
+    if (fs.existsSync(maintenancePath)) {
+        maintContent += fs.readFileSync(maintenancePath, 'utf8');
+    }
+
+    // Also scan maintenance modules
+    const maintModulesDir = path.join(modRoot, 'src', 'specializations', 'maintenance');
+    if (fs.existsSync(maintModulesDir)) {
+        const moduleFiles = fs.readdirSync(maintModulesDir).filter(f => f.endsWith('.lua'));
+        for (const file of moduleFiles) {
+            try {
+                maintContent += '\n' + fs.readFileSync(path.join(maintModulesDir, file), 'utf8');
+            } catch (e) {}
+        }
+    }
+
+    if (maintContent.length > 0) {
+
+        // Detect tracked metrics
+        const metricsPatterns = [
+            { pattern: /spec\.oilLevel/g, metric: 'Engine Oil Level', icon: '🛢️', unit: '0-100%' },
+            { pattern: /spec\.hydraulicFluidLevel/g, metric: 'Hydraulic Fluid Level', icon: '💧', unit: '0-100%' },
+            { pattern: /spec\.tireQuality/g, metric: 'Tire Quality Grade', icon: '⚙️', unit: '1-3' },
+            { pattern: /spec\.tireCondition/g, metric: 'Tire Condition', icon: '🔄', unit: '0-100%' },
+            { pattern: /spec\.operatingHours/g, metric: 'Operating Hours', icon: '⏱️', unit: 'hours' },
+            { pattern: /spec\.lastOilChange/g, metric: 'Last Oil Change', icon: '📅', unit: 'hours ago' },
+            { pattern: /spec\.lastHydraulicService/g, metric: 'Last Hydraulic Service', icon: '🔧', unit: 'hours ago' },
+            { pattern: /spec\.reliabilityScore/g, metric: 'Reliability Score', icon: '📊', unit: '0-100' },
+            { pattern: /spec\.engineTemperature/g, metric: 'Engine Temperature', icon: '🌡️', unit: '°C' },
+            { pattern: /spec\.engineHealth/g, metric: 'Engine Health', icon: '❤️', unit: '0-100%' },
+            { pattern: /spec\.steeringPlay/g, metric: 'Steering Play', icon: '🎯', unit: '0-100%' },
+            { pattern: /spec\.hasInspectionCache/g, metric: 'Inspection Cache', icon: '📋', unit: 'bool' },
+            { pattern: /spec\.purchaseAge/g, metric: 'Purchase Age', icon: '📆', unit: 'hours' },
+            { pattern: /spec\.oilServiceInterval/g, metric: 'Oil Service Interval', icon: '⏰', unit: 'hours' },
+            { pattern: /spec\.hydraulicServiceInterval/g, metric: 'Hydraulic Service Interval', icon: '⏰', unit: 'hours' }
+        ];
+
+        for (const mp of metricsPatterns) {
+            if (mp.pattern.test(maintContent)) {
+                modInfo.vehicleMetrics.push({ name: mp.metric, icon: mp.icon, unit: mp.unit });
+            }
+            mp.pattern.lastIndex = 0;
+        }
+
+        // Detect malfunctions (based on actual spec variables in UsedPlusMaintenance)
+        const malfunctionPatterns = [
+            { pattern: /spec\.isStalled/g, malf: 'Engine Stall', icon: '🛑', desc: 'Engine stops unexpectedly' },
+            { pattern: /spec\.isCutout/g, malf: 'Electrical Cutout', icon: '⚡', desc: 'Electrical system failure' },
+            { pattern: /spec\.isOverheated/g, malf: 'Overheating', icon: '🔥', desc: 'Engine runs too hot' },
+            { pattern: /spec\.isDrifting/g, malf: 'Steering Drift', icon: '↔️', desc: 'Vehicle pulls to one side' },
+            { pattern: /spec\.hasFlatTire/g, malf: 'Flat Tire', icon: '🎈', desc: 'Tire puncture/blowout' },
+            { pattern: /spec\.hasOilLeak/g, malf: 'Oil Leak', icon: '🛢️', desc: 'Losing engine oil' },
+            { pattern: /spec\.hasHydraulicLeak/g, malf: 'Hydraulic Leak', icon: '💧', desc: 'Losing hydraulic fluid' },
+            { pattern: /spec\.hasFuelLeak/g, malf: 'Fuel Leak', icon: '⛽', desc: 'Losing fuel' },
+            { pattern: /spec\.engineSeized/g, malf: 'Engine Seizure', icon: '💀', desc: 'Permanent engine damage' }
+        ];
+
+        for (const mf of malfunctionPatterns) {
+            if (mf.pattern.test(maintContent)) {
+                modInfo.malfunctions.push({ name: mf.malf, icon: mf.icon, description: mf.desc });
+            }
+            mf.pattern.lastIndex = 0;
+        }
+    }
+
+    // Get maintenance module names
+    const maintModulesDirForNames = path.join(modRoot, 'src', 'specializations', 'maintenance');
+    if (fs.existsSync(maintModulesDirForNames)) {
+        modInfo.maintenanceModules = fs.readdirSync(maintModulesDirForNames)
+            .filter(f => f.endsWith('.lua'))
+            .map(f => f.replace('.lua', '').replace('Maintenance', ''));
+    } else {
+        modInfo.maintenanceModules = [];
+    }
+
+    // Scan for vanilla hooks (Utils.appendedFunction / prependedFunction)
+    modInfo.vanillaHooks = [];
+    modInfo.eventSubscriptions = [];
+
+    const srcDirForHooks = path.join(modRoot, 'src');
+    if (fs.existsSync(srcDirForHooks)) {
+        const luaFilesForHooks = findFiles(srcDirForHooks, /\.lua$/);
+
+        for (const file of luaFilesForHooks) {
+            try {
+                const content = fs.readFileSync(file, 'utf8');
+                const relPath = path.relative(modRoot, file).replace(/\\/g, '/');
+                const fileName = path.basename(file, '.lua');
+
+                // Find Utils.appendedFunction hooks
+                const appendRegex = /(\w+(?:\.\w+)*)\s*=\s*Utils\.appendedFunction\s*\(\s*(\w+(?:\.\w+)*)/g;
+                let match;
+                while ((match = appendRegex.exec(content)) !== null) {
+                    const target = match[2];
+                    // Skip if target matches the first part (self-reference)
+                    if (!target.startsWith(fileName)) {
+                        modInfo.vanillaHooks.push({
+                            type: 'append',
+                            target: target,
+                            source: relPath
+                        });
+                    }
+                }
+
+                // Find Utils.prependedFunction hooks
+                const prependRegex = /(\w+(?:\.\w+)*)\s*=\s*Utils\.prependedFunction\s*\(\s*(\w+(?:\.\w+)*)/g;
+                while ((match = prependRegex.exec(content)) !== null) {
+                    const target = match[2];
+                    if (!target.startsWith(fileName)) {
+                        modInfo.vanillaHooks.push({
+                            type: 'prepend',
+                            target: target,
+                            source: relPath
+                        });
+                    }
+                }
+
+                // Find g_messageCenter:subscribe
+                const subscribeRegex = /g_messageCenter:subscribe\s*\(\s*MessageType\.(\w+)/g;
+                while ((match = subscribeRegex.exec(content)) !== null) {
+                    const existing = modInfo.eventSubscriptions.find(e => e.event === match[1] && e.source === relPath);
+                    if (!existing) {
+                        modInfo.eventSubscriptions.push({
+                            event: match[1],
+                            source: relPath
+                        });
+                    }
+                }
+            } catch (e) {}
+        }
+
+        // Remove duplicates from hooks (same target might be hooked in multiple places)
+        const uniqueHooks = [];
+        const seenHooks = new Set();
+        for (const hook of modInfo.vanillaHooks) {
+            const key = `${hook.type}:${hook.target}`;
+            if (!seenHooks.has(key)) {
+                seenHooks.add(key);
+                uniqueHooks.push(hook);
+            }
+        }
+        modInfo.vanillaHooks = uniqueHooks;
+    }
+
+    return modInfo;
+}
+
+/**
+ * Print mod-specific information
+ */
+function printModInfo(modInfo, stats) {
+    console.log(`\n${colors.bold}${colors.cyan}=== Mod Information ===${colors.reset}\n`);
+
+    // Header
+    console.log(`${colors.bold}${modInfo.title}${colors.reset}`);
+    console.log(`  Version:          ${modInfo.version}`);
+    console.log(`  Author:           ${modInfo.author}`);
+    console.log(`  Multiplayer:      ${modInfo.multiplayer ? colors.green + 'Supported' + colors.reset : colors.red + 'No' + colors.reset}`);
+    console.log('');
+
+    // Features
+    console.log(`${colors.bold}Features Implemented (${modInfo.features.length}):${colors.reset}`);
+    const featureCols = 2;
+    const featureRows = Math.ceil(modInfo.features.length / featureCols);
+    for (let row = 0; row < featureRows; row++) {
+        let line = '';
+        for (let col = 0; col < featureCols; col++) {
+            const idx = row + col * featureRows;
+            if (idx < modInfo.features.length) {
+                const f = modInfo.features[idx];
+                line += `  ${f.icon} ${f.name.padEnd(35)}`;
+            }
+        }
+        console.log(line);
+    }
+    console.log('');
+
+    // Cross-mod compatibility
+    if (modInfo.crossModCompat.length > 0) {
+        console.log(`${colors.bold}Cross-Mod Compatibility (${modInfo.crossModCompat.length}):${colors.reset}`);
+        for (const cm of modInfo.crossModCompat) {
+            console.log(`  ${cm.icon} ${cm.name}`);
+        }
+        console.log('');
+    }
+
+    // Translations
+    console.log(`${colors.bold}Language Support (${modInfo.translations.length}):${colors.reset}`);
+    console.log(`  ${modInfo.translations.join(', ')}`);
+    console.log('');
+
+    // Input bindings
+    if (modInfo.inputActions.length > 0) {
+        console.log(`${colors.bold}Keyboard Shortcuts (${modInfo.inputActions.length}):${colors.reset}`);
+        for (const action of modInfo.inputActions) {
+            // Clean up action name for display
+            const displayName = action.replace('USEDPLUS_', '').replace(/_/g, ' ');
+            console.log(`  ⌨️  ${displayName}`);
+        }
+        console.log('');
+    }
+
+    // Store items
+    if (modInfo.storeItems.length > 0) {
+        console.log(`${colors.bold}Store Items (${modInfo.storeItems.length}):${colors.reset}`);
+        for (const item of modInfo.storeItems) {
+            const itemName = path.basename(item, '.xml');
+            console.log(`  🛒 ${itemName}`);
+        }
+        console.log('');
+    }
+
+    // Specializations
+    const totalSpecs = modInfo.specializations.vehicle.length + modInfo.specializations.placeable.length;
+    if (totalSpecs > 0) {
+        console.log(`${colors.bold}Custom Specializations (${totalSpecs}):${colors.reset}`);
+        for (const spec of modInfo.specializations.vehicle) {
+            console.log(`  🚜 ${spec} (Vehicle)`);
+        }
+        for (const spec of modInfo.specializations.placeable) {
+            console.log(`  🏭 ${spec} (Placeable)`);
+        }
+        console.log('');
+    }
+
+    // Settings count
+    if (modInfo.settings.length > 0) {
+        console.log(`${colors.bold}Configurable Settings:${colors.reset} ${modInfo.settings.length} options`);
+        console.log('');
+    }
+
+    // Console commands
+    if (modInfo.consoleCommands && modInfo.consoleCommands.length > 0) {
+        console.log(`${colors.bold}Console Commands (${modInfo.consoleCommands.length}):${colors.reset}`);
+        for (const cmd of modInfo.consoleCommands) {
+            console.log(`  💻 ${colors.cyan}${cmd.name}${colors.reset}`);
+            console.log(`      ${cmd.description}`);
+        }
+        console.log('');
+    }
+
+    // Vanilla hooks
+    if (modInfo.vanillaHooks && modInfo.vanillaHooks.length > 0) {
+        console.log(`${colors.bold}${colors.red}=== Vanilla Game Hooks ===${colors.reset}\n`);
+
+        // Group by class
+        const hooksByClass = {};
+        for (const hook of modInfo.vanillaHooks) {
+            const parts = hook.target.split('.');
+            const className = parts[0];
+            if (!hooksByClass[className]) {
+                hooksByClass[className] = [];
+            }
+            hooksByClass[className].push(hook);
+        }
+
+        console.log(`${colors.bold}Hooked Functions (${modInfo.vanillaHooks.length}):${colors.reset}`);
+        for (const [className, hooks] of Object.entries(hooksByClass).sort()) {
+            console.log(`  ${colors.yellow}${className}${colors.reset}`);
+            for (const hook of hooks) {
+                const funcName = hook.target.split('.').slice(1).join('.');
+                const hookType = hook.type === 'prepend' ? '⬆️ PRE' : '⬇️ POST';
+                console.log(`    ${hookType}  ${funcName}`);
+            }
+        }
+        console.log('');
+
+        // Event subscriptions
+        if (modInfo.eventSubscriptions && modInfo.eventSubscriptions.length > 0) {
+            console.log(`${colors.bold}Event Subscriptions (${modInfo.eventSubscriptions.length}):${colors.reset}`);
+            const eventGroups = {};
+            for (const sub of modInfo.eventSubscriptions) {
+                if (!eventGroups[sub.event]) {
+                    eventGroups[sub.event] = [];
+                }
+                const shortSource = sub.source.split('/').pop();
+                if (!eventGroups[sub.event].includes(shortSource)) {
+                    eventGroups[sub.event].push(shortSource);
+                }
+            }
+            for (const [event, sources] of Object.entries(eventGroups).sort()) {
+                console.log(`  📡 MessageType.${event}`);
+                console.log(`      → ${sources.join(', ')}`);
+            }
+            console.log('');
+        }
+    }
+
+    // Vehicle Maintenance System
+    if ((modInfo.vehicleMetrics && modInfo.vehicleMetrics.length > 0) ||
+        (modInfo.malfunctions && modInfo.malfunctions.length > 0)) {
+        console.log(`${colors.bold}${colors.yellow}=== Vehicle Maintenance System ===${colors.reset}\n`);
+
+        // Maintenance modules
+        if (modInfo.maintenanceModules && modInfo.maintenanceModules.length > 0) {
+            console.log(`${colors.bold}Maintenance Modules (${modInfo.maintenanceModules.length}):${colors.reset}`);
+            console.log(`  ${modInfo.maintenanceModules.join(', ')}`);
+            console.log('');
+        }
+
+        // Vehicle metrics
+        if (modInfo.vehicleMetrics && modInfo.vehicleMetrics.length > 0) {
+            console.log(`${colors.bold}Vehicle Metrics Tracked (${modInfo.vehicleMetrics.length}):${colors.reset}`);
+            for (const m of modInfo.vehicleMetrics) {
+                console.log(`  ${m.icon} ${m.name.padEnd(28)} (${m.unit})`);
+            }
+            console.log('');
+        }
+
+        // Malfunctions
+        if (modInfo.malfunctions && modInfo.malfunctions.length > 0) {
+            console.log(`${colors.bold}Malfunction Events (${modInfo.malfunctions.length}):${colors.reset}`);
+            for (const mf of modInfo.malfunctions) {
+                console.log(`  ${mf.icon} ${mf.name.padEnd(20)} - ${mf.description}`);
+            }
+            console.log('');
+        }
+    }
+
+    // Quick stats summary
+    console.log(`${colors.bold}Quick Stats:${colors.reset}`);
+    console.log(`  📁 ${stats.lua.total} Lua files | ${stats.xml.total} XML files`);
+    console.log(`  📝 ${stats.lua.codeLines.toLocaleString()} lines of code | ${stats.lua.commentLines.toLocaleString()} comments`);
+    console.log(`  🖥️  ${stats.dialogs} dialogs | ${stats.events} event types | ${stats.managers} managers`);
+    console.log(`  💾 ${formatFileSize(stats.lua.totalSize + stats.xml.totalSize)} total size`);
+}
+
+/**
+ * Main function
+ */
+function main() {
+    const args = process.argv.slice(2);
+    const verbose = args.includes('--verbose') || args.includes('-v');
+    const checkFunctions = args.includes('--check-functions') || args.includes('-f');
+
+    console.log(`\n${colors.bold}${colors.cyan}=== FS25_UsedPlus Unused Code Scanner ===${colors.reset}\n`);
+
+    const modRoot = getModRoot();
+    console.log(`Mod root: ${modRoot}\n`);
+
+    let issuesFound = 0;
+
+    // === Check 1: Unregistered Lua files ===
+    console.log(`${colors.bold}[1] Checking for unregistered Lua files...${colors.reset}`);
+    const registered = parseModDescSources(modRoot);
+    const allLua = findAllLuaFiles(modRoot);
+
+    const unregistered = [...allLua].filter(f => !registered.has(f));
+    if (unregistered.length > 0) {
+        console.log(`${colors.yellow}  Found ${unregistered.length} unregistered file(s):${colors.reset}`);
+        for (const f of unregistered.sort()) {
+            console.log(`    - ${f}`);
+            issuesFound++;
+        }
+    } else {
+        console.log(`${colors.green}  All Lua files are registered in modDesc.xml${colors.reset}`);
+    }
+
+    // === Check 2: Orphaned dialogs ===
+    console.log(`\n${colors.bold}[2] Checking for orphaned dialogs...${colors.reset}`);
+    const dialogs = findAllDialogs(modRoot);
+    const orphanedDialogs = [];
+
+    for (const [dialogName, files] of Object.entries(dialogs)) {
+        const refs = searchDialogReferences(modRoot, dialogName);
+        if (refs.length === 0) {
+            orphanedDialogs.push({ name: dialogName, ...files });
+        }
+    }
+
+    if (orphanedDialogs.length > 0) {
+        console.log(`${colors.yellow}  Found ${orphanedDialogs.length} potentially orphaned dialog(s):${colors.reset}`);
+        for (const dialog of orphanedDialogs) {
+            console.log(`    - ${dialog.name}`);
+            if (dialog.lua) console.log(`        Lua: ${path.relative(modRoot, dialog.lua)}`);
+            if (dialog.xml) console.log(`        XML: ${path.relative(modRoot, dialog.xml)}`);
+            issuesFound++;
+        }
+    } else {
+        console.log(`${colors.green}  All dialogs appear to be in use${colors.reset}`);
+    }
+
+    // === Check 3: Mismatched dialog pairs ===
+    console.log(`\n${colors.bold}[3] Checking for mismatched dialog pairs...${colors.reset}`);
+    const mismatched = [];
+
+    for (const [dialogName, files] of Object.entries(dialogs)) {
+        if (files.lua && !files.xml) {
+            mismatched.push({ name: dialogName, issue: 'Missing XML' });
+        } else if (files.xml && !files.lua) {
+            mismatched.push({ name: dialogName, issue: 'Missing Lua' });
+        }
+    }
+
+    if (mismatched.length > 0) {
+        console.log(`${colors.yellow}  Found ${mismatched.length} mismatched pair(s):${colors.reset}`);
+        for (const item of mismatched) {
+            console.log(`    - ${item.name}: ${item.issue}`);
+            issuesFound++;
+        }
+    } else {
+        console.log(`${colors.green}  All dialogs have matching Lua/XML pairs${colors.reset}`);
+    }
+
+    // === Summary ===
+    console.log(`\n${colors.bold}${'='.repeat(50)}${colors.reset}`);
+    if (issuesFound > 0) {
+        console.log(`${colors.yellow}Found ${issuesFound} potential issue(s) to review${colors.reset}`);
+    } else {
+        console.log(`${colors.green}No issues found!${colors.reset}`);
+    }
+
+    // === Mod Info & Statistics ===
+    const stats = gatherStatistics(modRoot);
+    const modInfo = gatherModInfo(modRoot);
+    printModInfo(modInfo, stats);
+    printStatistics(stats);
+
+    console.log(`\n${colors.cyan}Options:${colors.reset}`);
+    console.log('  --verbose, -v          Show more details');
+    console.log('  --check-functions, -f  Check for unused functions (not yet implemented)');
+
+    return issuesFound;
+}
+
+// Run
+process.exit(main());

--- a/tools/find_unused.js
+++ b/tools/find_unused.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * FS25_UsedPlus - Find Unused Code Scanner
+ * FS25_MarketDynamics - Find Unused Code Scanner
  *
  * Scans the codebase for potentially orphaned:
  * - Lua files not registered in modDesc.xml
@@ -114,16 +114,18 @@ function findAllDialogs(modRoot) {
         }
     }
 
-    // Find XML dialog files in gui/
-    const xmlDir = path.join(modRoot, 'gui');
-    if (fs.existsSync(xmlDir)) {
-        const xmlFiles = findFiles(xmlDir, /Dialog\.xml$/);
-        for (const file of xmlFiles) {
-            const name = path.basename(file, '.xml');
-            if (dialogs[name]) {
-                dialogs[name].xml = file;
-            } else {
-                dialogs[name] = { lua: null, xml: file };
+    // Find XML dialog files in xml/gui/ (primary) and gui/ (settings page)
+    for (const xmlRelDir of [path.join('xml', 'gui'), 'gui']) {
+        const xmlDir = path.join(modRoot, xmlRelDir);
+        if (fs.existsSync(xmlDir)) {
+            const xmlFiles = findFiles(xmlDir, /Dialog\.xml$/);
+            for (const file of xmlFiles) {
+                const name = path.basename(file, '.xml');
+                if (dialogs[name]) {
+                    dialogs[name].xml = file;
+                } else {
+                    dialogs[name] = { lua: null, xml: file };
+                }
             }
         }
     }
@@ -275,19 +277,7 @@ function gatherStatistics(modRoot) {
     // Categories to track
     const categories = {
         'src/gui': 'GUI Screens',
-        'src/gui/financepanels': 'Finance Panels',
         'src/events': 'Network Events',
-        'src/managers': 'Managers',
-        'src/managers/usedvehicle': 'Used Vehicle Modules',
-        'src/extensions': 'Extensions',
-        'src/specializations': 'Specializations',
-        'src/specializations/maintenance': 'Maintenance Modules',
-        'src/utils': 'Utilities',
-        'src/data': 'Data Classes',
-        'src/settings': 'Settings',
-        'src/core': 'Core',
-        'vehicles': 'Vehicles',
-        'placeables': 'Placeables'
     };
 
     // Initialize categories
@@ -369,7 +359,7 @@ function gatherStatistics(modRoot) {
     stats.lua.largestFiles = stats.lua.largestFiles.slice(0, 10);
 
     // Count XML files
-    const xmlDirs = ['gui', 'translations'];
+    const xmlDirs = ['gui', path.join('xml', 'gui'), 'translations'];
     for (const dir of xmlDirs) {
         const dirPath = path.join(modRoot, dir);
         if (fs.existsSync(dirPath)) {
@@ -541,36 +531,22 @@ function gatherModInfo(modRoot) {
 
     // Detect features from code patterns
     const featurePatterns = [
-        { pattern: /FinanceManager|FinanceDeal/g, feature: 'Vehicle/Equipment Financing', icon: '💰' },
-        { pattern: /LeaseDeal|LeaseVehicle/g, feature: 'Vehicle Leasing', icon: '📋' },
-        { pattern: /LandLeaseDeal|LandLeaseEvent/g, feature: 'Land Leasing', icon: '🏞️' },
-        { pattern: /CreditSystem|CreditScore/g, feature: 'Dynamic Credit Scoring (300-850)', icon: '📊' },
-        { pattern: /TakeLoanDialog|TakeLoanEvent/g, feature: 'Collateral-Based Cash Loans', icon: '🏦' },
-        { pattern: /UsedVehicleManager|UsedVehicleSearch/g, feature: 'Used Vehicle Marketplace', icon: '🚜' },
-        { pattern: /VehicleSaleManager|VehicleSaleListing/g, feature: 'Agent-Based Vehicle Sales', icon: '🏷️' },
-        { pattern: /NegotiationDialog|SellerResponseDialog/g, feature: 'Price Negotiation System', icon: '🤝' },
-        { pattern: /InspectionReport|VehicleInspection/g, feature: 'Vehicle Inspection Reports', icon: '🔍' },
-        { pattern: /RepairDialog|RepairVehicleEvent/g, feature: 'Partial Repair System (1-100%)', icon: '🔧' },
-        { pattern: /TiresDialog|MaintenanceTires/g, feature: 'Tire Replacement System', icon: '⚙️' },
-        { pattern: /FluidsDialog|MaintenanceFluids/g, feature: 'Fluid Service (Oil/Hydraulic)', icon: '🛢️' },
-        { pattern: /FieldServiceKit/g, feature: 'Field Service Kit (Roadside Repairs)', icon: '🧰' },
-        { pattern: /OBDScanner|DiagnosisData/g, feature: 'OBD Scanner Diagnostics', icon: '📟' },
-        { pattern: /MaintenanceReliability|MaintenanceEngine/g, feature: 'Component Reliability System', icon: '⚡' },
-        { pattern: /TradeInCalculations|tradeIn/gi, feature: 'Trade-In System', icon: '🔄' },
-        { pattern: /DepreciationCalculations/g, feature: 'Realistic Depreciation', icon: '📉' },
-        { pattern: /DifficultyScalingManager/g, feature: 'Difficulty-Based Pricing', icon: '⚖️' },
-        { pattern: /BankInterestManager/g, feature: 'Bank Interest on Cash', icon: '💵' },
-        { pattern: /PaymentTracker|PaymentHistory/g, feature: 'Payment History Tracking', icon: '📅' },
-        { pattern: /RepossessionDialog/g, feature: 'Vehicle Repossession System', icon: '🚨' },
-        { pattern: /FinanceManagerFrame/g, feature: 'ESC Menu Finance Manager', icon: '📱' },
-        { pattern: /FinancialDashboard/g, feature: 'Financial Dashboard', icon: '📈' }
+        { pattern: /MarketEngine/g, feature: 'Dynamic Market Engine', icon: '📈' },
+        { pattern: /WorldEventSystem/g, feature: 'World Event System', icon: '🌍' },
+        { pattern: /FuturesMarket/g, feature: 'Futures Market Trading', icon: '💹' },
+        { pattern: /MarketSerializer/g, feature: 'Market Data Persistence', icon: '💾' },
+        { pattern: /PriceHook/g, feature: 'Price Hook Integration', icon: '🔌' },
+        { pattern: /MDMContractDialog/g, feature: 'Contract System', icon: '📋' },
+        { pattern: /MDMHUD/g, feature: 'Market HUD Display', icon: '🖥️' },
+        { pattern: /MarketScreen/g, feature: 'Market Screen UI', icon: '📊' },
+        { pattern: /AdminCommands/g, feature: 'Admin Console Commands', icon: '💻' },
     ];
 
     // Detect cross-mod compatibility
     const crossModPatterns = [
-        { pattern: /RVB|RealisticVehicleBreakdown/gi, mod: 'FS25_RealisticVehicleBreakdown (RVB)', icon: '🔗' },
-        { pattern: /UYT|UsedYourTool/gi, mod: 'FS25_UsedYourTool (UYT)', icon: '🔗' },
-        { pattern: /ModCompatibility/g, mod: 'Generic Mod Compatibility Layer', icon: '🔌' }
+        { pattern: /BCIntegration/g, mod: 'FS25_BetterContracts integration', icon: '🔗' },
+        { pattern: /UPIntegration/g, mod: 'FS25_UsedPlus integration', icon: '🔗' },
+        { pattern: /RWEIntegration/g, mod: 'FS25_RandomWorldEvents integration', icon: '🔗' },
     ];
 
     // Scan source files for features
@@ -599,8 +575,8 @@ function gatherModInfo(modRoot) {
         }
     }
 
-    // Count settings from UsedPlusSettings
-    const settingsPath = path.join(modRoot, 'src', 'settings', 'UsedPlusSettings.lua');
+    // Count settings from MDMEventConfig
+    const settingsPath = path.join(modRoot, 'src', 'MDMEventConfig.lua');
     if (fs.existsSync(settingsPath)) {
         const settingsContent = fs.readFileSync(settingsPath, 'utf8');
         const settingRegex = /["'](\w+)["']\s*[=:]/g;
@@ -617,7 +593,7 @@ function gatherModInfo(modRoot) {
 
     // Scan for console commands
     modInfo.consoleCommands = [];
-    const mainPath = path.join(modRoot, 'src', 'main.lua');
+    const mainPath = path.join(modRoot, 'main.lua');
     if (fs.existsSync(mainPath)) {
         const mainContent = fs.readFileSync(mainPath, 'utf8');
         const cmdRegex = /addConsoleCommand\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"/g;
@@ -971,7 +947,7 @@ function main() {
     const verbose = args.includes('--verbose') || args.includes('-v');
     const checkFunctions = args.includes('--check-functions') || args.includes('-f');
 
-    console.log(`\n${colors.bold}${colors.cyan}=== FS25_UsedPlus Unused Code Scanner ===${colors.reset}\n`);
+    console.log(`\n${colors.bold}${colors.cyan}=== FS25_MarketDynamics Unused Code Scanner ===${colors.reset}\n`);
 
     const modRoot = getModRoot();
     console.log(`Mod root: ${modRoot}\n`);

--- a/tools/run_all_checks.bat
+++ b/tools/run_all_checks.bat
@@ -1,0 +1,37 @@
+@echo off
+REM ================================================================
+REM FS25_MarketDynamics Validation Suite
+REM Run this before testing in-game or releasing
+REM ================================================================
+
+echo.
+echo ========================================
+echo   FS25_MarketDynamics Validation Suite
+echo ========================================
+echo.
+
+cd /d "%~dp0"
+
+echo Running static analysis...
+echo.
+powershell -ExecutionPolicy Bypass -File validate_mod.ps1
+set VALIDATE_RESULT=%ERRORLEVEL%
+
+echo.
+echo ========================================
+echo.
+echo To analyze game logs after testing, run:
+echo   powershell -ExecutionPolicy Bypass -File extract_log_errors.ps1
+echo.
+echo ========================================
+echo.
+
+REM Summarize
+if %VALIDATE_RESULT% NEQ 0 (
+    echo [REVIEW] Static analysis found issues to review
+) else (
+    echo [PASSED] Static analysis - no errors found
+)
+
+echo.
+pause

--- a/tools/test_global_leaks.lua
+++ b/tools/test_global_leaks.lua
@@ -1,0 +1,64 @@
+--[[
+    Test script to demonstrate global variable leaks
+    Run with: lua test_global_leaks.lua
+]]
+
+print("=== GLOBAL LEAK DEMONSTRATION ===\n")
+
+-- Simulate the buggy pattern
+function buggyRepairEvent(farmId, vehicleId, component, cost)
+    component = component or "all"
+    cost = cost or 0  -- BUG: Creates global!
+
+    print(string.format("  Repair: farmId=%d, cost=%d", farmId, cost))
+    return cost
+end
+
+-- Simulate the fixed pattern
+function fixedRepairEvent(farmId, vehicleId, component, cost)
+    local component = component or "all"
+    local cost = cost or 0  -- Safe: Local
+
+    print(string.format("  Repair: farmId=%d, cost=%d", farmId, cost))
+    return cost
+end
+
+print("--- BUGGY VERSION ---")
+print("Call 1: cost=5000")
+buggyRepairEvent(1, 123, "engine", 5000)
+print(string.format("Global 'cost' after call 1: %s\n", tostring(cost)))
+
+print("Call 2: cost=nil (should default to 0)")
+buggyRepairEvent(2, 456, "engine", nil)
+print(string.format("Global 'cost' after call 2: %s\n", tostring(cost)))
+
+print("Call 3: cost=0 explicitly")
+buggyRepairEvent(3, 789, "engine", 0)
+print(string.format("Global 'cost' after call 3: %s\n", tostring(cost)))
+
+-- Reset global
+cost = nil
+
+print("\n--- FIXED VERSION ---")
+print("Call 1: cost=5000")
+fixedRepairEvent(1, 123, "engine", 5000)
+print(string.format("Global 'cost' after call 1: %s\n", tostring(cost)))
+
+print("Call 2: cost=nil (should default to 0)")
+fixedRepairEvent(2, 456, "engine", nil)
+print(string.format("Global 'cost' after call 2: %s\n", tostring(cost)))
+
+print("Call 3: cost=0 explicitly")
+fixedRepairEvent(3, 789, "engine", 0)
+print(string.format("Global 'cost' after call 3: %s\n", tostring(cost)))
+
+print("\n=== EXPECTED OUTPUT ===")
+print("Buggy version: Global 'cost' should leak (5000, then 0)")
+print("Fixed version: Global 'cost' should stay nil")
+
+print("\n=== MULTIPLAYER SCENARIO ===")
+print("If two clients call buggyRepairEvent() with different costs,")
+print("the global 'cost' will persist between calls, causing:")
+print("  1. Client A charges $5000 (correct)")
+print("  2. Client B charges $5000 (WRONG - should be $0)")
+print("  3. Money mysteriously disappears!")

--- a/tools/validate_mod.ps1
+++ b/tools/validate_mod.ps1
@@ -124,9 +124,9 @@ foreach ($file in $LuaFiles) {
             }
         }
 
-        # Check for debug code (skip comments and the core logging file itself)
-        if (-not $isComment -and $line -match '\bprint\s*\(' -and $line -notmatch 'MarketDynamics\.log' -and $RelPath -notmatch 'MarketDynamicsCore\.lua') {
-            Add-Warning -File $RelPath -Category "DEBUG_CODE" -Line $lineNum -Message "Raw print() - use MDM.log* instead"
+        # Check for debug code (skip comments, logger, dev tools, and AdminCommands where print() is intentional for console output)
+        if (-not $isComment -and $line -match '\bprint\s*\(' -and $RelPath -notmatch 'Logger\.lua' -and $RelPath -notmatch '^tools\\' -and $RelPath -notmatch 'AdminCommands\.lua') {
+            Add-Warning -File $RelPath -Category "DEBUG_CODE" -Line $lineNum -Message "Raw print() - use the mod logger instead"
         }
     }
 }

--- a/tools/validate_mod.ps1
+++ b/tools/validate_mod.ps1
@@ -1,0 +1,318 @@
+<#
+.SYNOPSIS
+    FS25_MarketDynamics Mod Validator (PowerShell version)
+    Static analysis tool to catch common errors before loading in-game.
+
+.DESCRIPTION
+    Performs the following checks:
+    - Lua pitfall detection (goto, os.time, etc.)
+    - XML well-formedness
+    - Callback cross-reference (XML onClick -> Lua function)
+    - Translation key validation
+    - modDesc.xml source file validation
+    - Debug code detection
+
+.EXAMPLE
+    .\validate_mod.ps1
+
+.EXAMPLE
+    .\validate_mod.ps1 -Verbose
+#>
+
+param(
+    [switch]$Verbose
+)
+
+# Get mod path (script is in tools/ subdirectory)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ModPath = Split-Path -Parent $ScriptDir
+
+# Validation results
+$Errors = @()
+$Warnings = @()
+
+function Add-Error {
+    param([string]$File, [string]$Category, [int]$Line, [string]$Message)
+    $script:Errors += [PSCustomObject]@{
+        File = $File
+        Category = $Category
+        Line = $Line
+        Message = $Message
+    }
+}
+
+function Add-Warning {
+    param([string]$File, [string]$Category, [int]$Line, [string]$Message)
+    $script:Warnings += [PSCustomObject]@{
+        File = $File
+        Category = $Category
+        Line = $Line
+        Message = $Message
+    }
+}
+
+function Write-Header {
+    param([string]$Text)
+    Write-Host "`n$('=' * 50)" -ForegroundColor Cyan
+    Write-Host $Text -ForegroundColor Cyan
+    Write-Host "$('=' * 50)" -ForegroundColor Cyan
+}
+
+function Write-Check {
+    param([string]$Text)
+    Write-Host "  Checking: $Text..." -ForegroundColor Blue
+}
+
+# Verify mod path
+if (-not (Test-Path (Join-Path $ModPath "modDesc.xml"))) {
+    Write-Host "Error: modDesc.xml not found at $ModPath" -ForegroundColor Red
+    exit 1
+}
+
+Write-Header "FS25_MarketDynamics Mod Validator"
+Write-Host "Mod Path: $ModPath" -ForegroundColor Gray
+Write-Host "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
+
+# ============================================================
+# Phase 1: Collect Lua function names
+# ============================================================
+Write-Host "`nPhase 1: Collecting data..." -ForegroundColor Blue
+
+$LuaFunctions = @{}
+$LuaFiles = Get-ChildItem -Path $ModPath -Filter "*.lua" -Recurse
+
+Write-Host "  Found $($LuaFiles.Count) Lua files" -ForegroundColor Gray
+
+foreach ($file in $LuaFiles) {
+    $RelPath = $file.FullName.Substring($ModPath.Length + 1)
+    $content = Get-Content $file.FullName -Raw -ErrorAction SilentlyContinue
+    if (-not $content) { continue }
+
+    $lines = $content -split "`n"
+    $LuaFunctions[$RelPath] = @()
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        $lineNum = $i + 1
+
+        # Find function definitions
+        if ($line -match 'function\s+(?:\w+[:.])?([\w]+)\s*\(') {
+            $LuaFunctions[$RelPath] += $matches[1]
+        }
+
+        # Skip comment lines and comment blocks
+        $trimmedLine = $line.Trim()
+        $isComment = $trimmedLine.StartsWith('--') -or $trimmedLine.StartsWith('Note:')
+
+        # Check for Lua pitfalls (only in actual code, not comments)
+        # Only check patterns that indicate actual code issues
+        $pitfalls = @(
+            @{Pattern = '^\s*goto\s+\w'; Message = "Lua 5.1 does not support 'goto' (FS25 uses Lua 5.1)"},
+            @{Pattern = '::\w+::'; Message = "Lua 5.1 does not support labels '::label::'"},
+            @{Pattern = '=\s*os\.time\s*\('; Message = "os.time() not available - use g_currentMission.time"},
+            @{Pattern = '=\s*os\.date\s*\('; Message = "os.date() not available - use g_currentMission.environment"},
+            @{Pattern = 'setTextColorByName\s*\('; Message = "setTextColorByName() doesn't exist - use setTextColor(r,g,b,a)"},
+            # Only flag DialogElement class extension, not constant usage like DialogElement.TYPE_INFO
+            @{Pattern = 'DialogElement\s*[.:]new\s*\(|extends.*DialogElement'; Message = "DialogElement is deprecated - use MessageDialog pattern"}
+        )
+
+        if (-not $isComment) {
+            foreach ($pitfall in $pitfalls) {
+                if ($line -match $pitfall.Pattern) {
+                    Add-Error -File $RelPath -Category "LUA_PITFALL" -Line $lineNum -Message $pitfall.Message
+                }
+            }
+        }
+
+        # Check for debug code (skip comments and the core logging file itself)
+        if (-not $isComment -and $line -match '\bprint\s*\(' -and $line -notmatch 'MarketDynamics\.log' -and $RelPath -notmatch 'MarketDynamicsCore\.lua') {
+            Add-Warning -File $RelPath -Category "DEBUG_CODE" -Line $lineNum -Message "Raw print() - use MDM.log* instead"
+        }
+    }
+}
+
+# Build flat list of all function names
+$AllFunctions = @()
+foreach ($funcs in $LuaFunctions.Values) {
+    $AllFunctions += $funcs
+}
+$AllFunctions = $AllFunctions | Select-Object -Unique
+Write-Host "  Found $($AllFunctions.Count) Lua functions" -ForegroundColor Gray
+
+# ============================================================
+# Phase 2: Collect XML callbacks and validate
+# ============================================================
+$XmlFiles = Get-ChildItem -Path $ModPath -Filter "*.xml" -Recurse | Where-Object { $_.Name -notmatch 'modDesc|translation' }
+
+Write-Host "  Found $($XmlFiles.Count) GUI XML files" -ForegroundColor Gray
+
+$CallbackAttrs = @('onClick', 'onOpen', 'onClose', 'onCreate', 'onHighlight', 'onHighlightRemove',
+                   'onFocus', 'onFocusLeave', 'onChange', 'onCheckedChanged', 'onSelectionChanged')
+
+foreach ($file in $XmlFiles) {
+    $RelPath = $file.FullName.Substring($ModPath.Length + 1)
+
+    try {
+        $content = Get-Content $file.FullName -Raw -ErrorAction Stop
+        $lines = $content -split "`n"
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $line = $lines[$i]
+            $lineNum = $i + 1
+
+            foreach ($attr in $CallbackAttrs) {
+                if ($line -match "$attr=`"(\w+)`"") {
+                    $callback = $matches[1]
+                    # Skip base class callbacks
+                    if ($callback -in @('onOpen', 'onClose', 'onCreate', 'superClass')) {
+                        continue
+                    }
+                    if ($callback -notin $AllFunctions) {
+                        Add-Error -File $RelPath -Category "MISSING_CALLBACK" -Line $lineNum -Message "$attr=`"$callback`" - function not found in Lua"
+                    }
+                }
+            }
+        }
+
+        # Validate XML syntax
+        try {
+            [xml]$xml = $content
+        } catch {
+            Add-Error -File $RelPath -Category "XML_PARSE" -Line 0 -Message "XML parse error: $($_.Exception.Message)"
+        }
+
+    } catch {
+        Add-Error -File $RelPath -Category "FILE_READ" -Line 0 -Message "Could not read file: $($_.Exception.Message)"
+    }
+}
+
+# ============================================================
+# Phase 3: Translation key validation
+# ============================================================
+Write-Host "`nPhase 2: Cross-reference validation..." -ForegroundColor Blue
+
+$TransDir = Join-Path $ModPath "translations"
+$TransKeys = @()
+
+$EnFile = Join-Path $TransDir "translation_en.xml"
+if (Test-Path $EnFile) {
+    $enContent = Get-Content $EnFile -Raw
+    # Match both <e k="key" and <text name="key" formats
+    $keyMatches = [regex]::Matches($enContent, '<e\s+k="(\w+)"')
+    foreach ($match in $keyMatches) {
+        $TransKeys += $match.Groups[1].Value
+    }
+    $textMatches = [regex]::Matches($enContent, '<text\s+name="(\w+)"')
+    foreach ($match in $textMatches) {
+        $TransKeys += $match.Groups[1].Value
+    }
+    Write-Host "  Found $($TransKeys.Count) translation keys" -ForegroundColor Gray
+}
+
+# Check for missing translation keys in Lua files
+# Only flag mdm_* keys as missing (base game keys are expected to be in game's i18n)
+foreach ($file in $LuaFiles) {
+    $RelPath = $file.FullName.Substring($ModPath.Length + 1)
+    $content = Get-Content $file.FullName -Raw -ErrorAction SilentlyContinue
+    if (-not $content) { continue }
+
+    $lines = $content -split "`n"
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        $lineNum = $i + 1
+
+        # Skip comment lines
+        $trimmedLine = $line.Trim()
+        if ($trimmedLine.StartsWith('--')) { continue }
+
+        $keyMatches = [regex]::Matches($line, 'getText\s*\(\s*["''](\w+)["'']')
+        foreach ($match in $keyMatches) {
+            $key = $match.Groups[1].Value
+            # Only flag mdm_* keys as errors (base game keys are assumed to exist)
+            # Skip keys ending with _ (dynamic key construction like "mdm_fluid_" .. fluidType)
+            if ($key.StartsWith('mdm_') -and -not $key.EndsWith('_') -and $key -notin $TransKeys) {
+                Add-Error -File $RelPath -Category "MISSING_TRANSLATION" -Line $lineNum -Message "Translation key $key not found in translation_en.xml"
+            }
+        }
+    }
+}
+
+# ============================================================
+# Phase 4: modDesc validation
+# ============================================================
+Write-Host "`nPhase 3: modDesc validation..." -ForegroundColor Blue
+
+$ModDescPath = Join-Path $ModPath "modDesc.xml"
+$modDescContent = Get-Content $ModDescPath -Raw
+
+# Check source files exist
+$sourceMatches = [regex]::Matches($modDescContent, '<sourceFile\s+filename="([^"]+)"')
+foreach ($match in $sourceMatches) {
+    $srcFile = $match.Groups[1].Value
+    if (-not (Test-Path (Join-Path $ModPath $srcFile))) {
+        Add-Error -File "modDesc.xml" -Category "MISSING_SOURCE" -Line 0 -Message "sourceFile '$srcFile' does not exist"
+    }
+}
+
+# ============================================================
+# Print Results
+# ============================================================
+Write-Header "Validation Results"
+
+# Group errors by category
+$ErrorsByCategory = $Errors | Group-Object -Property Category
+
+if ($Errors.Count -gt 0) {
+    Write-Host "`nERRORS: $($Errors.Count)" -ForegroundColor Red -BackgroundColor Black
+
+    foreach ($group in $ErrorsByCategory) {
+        Write-Host "`n  [$($group.Name)] ($($group.Count) issues)" -ForegroundColor Red
+        $group.Group | Select-Object -First 10 | ForEach-Object {
+            $lineStr = if ($_.Line -gt 0) { ":$($_.Line)" } else { "" }
+            Write-Host "    $($_.File)$lineStr : $($_.Message)" -ForegroundColor Red
+        }
+        if ($group.Count -gt 10) {
+            Write-Host "    ... and $($group.Count - 10) more" -ForegroundColor Red
+        }
+    }
+} else {
+    Write-Host "`nERRORS: 0" -ForegroundColor Green
+}
+
+$WarningsByCategory = $Warnings | Group-Object -Property Category
+
+if ($Warnings.Count -gt 0) {
+    Write-Host "`nWARNINGS: $($Warnings.Count)" -ForegroundColor Yellow
+
+    foreach ($group in $WarningsByCategory) {
+        Write-Host "`n  [$($group.Name)] ($($group.Count) issues)" -ForegroundColor Yellow
+        $group.Group | Select-Object -First 10 | ForEach-Object {
+            $lineStr = if ($_.Line -gt 0) { ":$($_.Line)" } else { "" }
+            Write-Host "    $($_.File)$lineStr : $($_.Message)" -ForegroundColor Yellow
+        }
+        if ($group.Count -gt 10) {
+            Write-Host "    ... and $($group.Count - 10) more" -ForegroundColor Yellow
+        }
+    }
+} else {
+    Write-Host "`nWARNINGS: 0" -ForegroundColor Green
+}
+
+# Summary
+Write-Host "`n$('=' * 50)" -ForegroundColor Cyan
+if ($Errors.Count -eq 0 -and $Warnings.Count -eq 0) {
+    Write-Host "All checks passed!" -ForegroundColor Green
+} else {
+    Write-Host "Total: $($Errors.Count) errors, $($Warnings.Count) warnings" -ForegroundColor White
+    if ($Errors.Count -gt 0) {
+        Write-Host "Fix errors before loading in-game!" -ForegroundColor Red
+    }
+}
+Write-Host "$('=' * 50)`n" -ForegroundColor Cyan
+
+# Exit code
+if ($Errors.Count -gt 0) {
+    exit 1
+} else {
+    exit 0
+}

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -80,8 +80,6 @@
         <text name="mdm_screen_collecting"       text="Price history builds as time passes — check back soon" />
         <text name="mdm_screen_select_crop"      text="Select a commodity" />
         <text name="mdm_screen_no_events"        text="Markets are calm. Events may appear as conditions shift." />
-        <text name="mdm_screen_col_intensity"    text="Intensity" />
-        <text name="mdm_screen_col_time_left"    text="Time Left" />
         <text name="mdm_screen_new_contract"     text="N: New Contract" />
         <text name="mdm_screen_no_contracts"     text="No contracts yet. Press N to create one." />
         <text name="mdm_screen_at_risk"          text="AT RISK" />
@@ -266,8 +264,6 @@
         <text name="mdm_evt_ft_title_suffix"   text=" — Custom Fill Types" />
 
         <!-- Input action display names -->
-        <text name="input_MDM_MARKET_SCREEN" text="Open Market Screen" />
-        <text name="input_MDM_CREATE_CONTRACT" text="Create Futures Contract" />
         <text name="input_MDM_SETTINGS_PANEL" text="Market Dynamics Settings" />
         <text name="mdm_bc_dialog_suppressed" text="FS25_FuturesMission is active and handles contract creation. Use the Contracts page (ESC menu) to create futures contracts. Get it on GitHub: search FS25_FuturesMission by Mmtrx." />
     </texts>


### PR DESCRIPTION
## Summary

- Wrap `MDMContractRequestEvent:run()` body in `pcall` so any Lua error on the dedicated server is captured to the MDM log (`[MDM] ERROR MDMContractRequestEvent:run error: ...`) instead of dying silently in `packetReceived` — fixes issue #82 diagnosis
- Add detailed userId/farmId to security rejection warn lines for easier dedi log triage
- Close #81 (payment by design — total = locked_price × quantity) and #78 (resolved in v1.1.9.5, dedi tracked in #82)

## Test plan

- [ ] Start singleplayer session, create a contract — no Lua errors in log, contract appears in CONTRACTS tab
- [ ] Save and reload — contract persists
- [ ] Ask A-intheCode to test on dedi and report `[MDM] ERROR` line if creation still fails (issue #82 remains open)