### PR TITLE
fix: resolve #82 #84 #88 #90 - dedi crash, double delivery, event storms, frequency delay

### DIFF
--- a/src/PriceHook.lua
+++ b/src/PriceHook.lua
@@ -34,8 +34,6 @@ if _G.MDM_PriceHook_installed then
 end
 _G.MDM_PriceHook_installed = true
 
--- Re-entrancy guard to prevent double-counting if sellFillType calls addFillLevelFromTool
-local MDM_isInsideSellHook = false
 
 -- ---------------------------------------------------------------------------
 -- EconomyManager reference — used only for MDMGetVanillaPrice, never patched.
@@ -97,14 +95,9 @@ if SellingStation and SellingStation.sellFillType then
     SellingStation.sellFillType = Utils.overwrittenFunction(
         SellingStation.sellFillType,
         function(self, superFunc, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
-            local wasInside = MDM_isInsideSellHook
-            MDM_isInsideSellHook = true
-
             local result = superFunc(self, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
 
-            -- Only track on server; only when MDM is active with a futures market.
-            -- Use the re-entrancy guard to avoid double-counting if sellFillType calls addFillLevelFromTool.
-            if not wasInside and g_server ~= nil
+            if g_server ~= nil
                 and g_MarketDynamics and g_MarketDynamics.isActive
                 and g_MarketDynamics.futuresMarket then
 
@@ -119,7 +112,6 @@ if SellingStation and SellingStation.sellFillType then
                 end
             end
 
-            MDM_isInsideSellHook = wasInside
             return result
         end
     )
@@ -129,37 +121,9 @@ else
     MDMLog.warn("PriceHook: SellingStation.sellFillType not found — futures delivery tracking disabled")
 end
 
--- Fallback hook for addFillLevelFromTool which some selling stations use directly (e.g. trains)
-if SellingStation and SellingStation.addFillLevelFromTool then
-    SellingStation.addFillLevelFromTool = Utils.overwrittenFunction(
-        SellingStation.addFillLevelFromTool,
-        function(self, superFunc, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
-            local wasInside = MDM_isInsideSellHook
-            MDM_isInsideSellHook = true
-
-            local result = superFunc(self, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
-            
-            -- Some selling stations (trains, certain placeables) call addFillLevelFromTool
-            -- directly without going through sellFillType, so we must track here too.
-            -- We use the re-entrancy guard to avoid double-counting.
-            if not wasInside and g_server ~= nil
-                and g_MarketDynamics and g_MarketDynamics.isActive
-                and g_MarketDynamics.futuresMarket then
-
-                if result and result > 0 then
-                    MDMLog.debug(string.format("PriceHook: SellingStation.addFillLevelFromTool(farmId=%s, accepted=%.1f, ft=%s)",
-                        tostring(farmId), tostring(result), tostring(fillTypeIndex)))
-                    local pricePerLiter = self:getEffectiveFillTypePrice(fillTypeIndex)
-                    g_MarketDynamics.futuresMarket:onCropDelivered(farmId, fillTypeIndex, result, pricePerLiter)
-                end
-            end
-            
-            MDM_isInsideSellHook = wasInside
-            return result
-        end
-    )
-    MDMLog.info("PriceHook: SellingStation.addFillLevelFromTool hooked as fallback")
-end
+-- addFillLevelFromTool hook intentionally removed: standard selling stations call both
+-- sellFillType and addFillLevelFromTool at the same call-stack level, so the re-entrancy
+-- guard never engages and every delivery was double-counted. sellFillType is authoritative.
 
 -- ---------------------------------------------------------------------------
 -- Public helper: vanilla price snapshot for MarketEngine:init()

--- a/src/WorldEventSystem.lua
+++ b/src/WorldEventSystem.lua
@@ -208,14 +208,25 @@ function WorldEventSystem:_rollForEvents()
     local freqScale = (settings and settings.eventFrequency) or 1.0
     local disabled  = settings and settings.disabledEvents
 
+    -- Cap at one new event per check to prevent event storms.
+    -- Shuffle registry order so no single event is systematically favored.
+    local eligible = {}
     for id, event in pairs(self.registry) do
         if not (disabled and disabled[id]) and not self.active[id] then
             local cooldown = event.cooldownMs or MIN_COOLDOWN_MS
             if (now - event.lastFiredAt) >= cooldown then
-                if math.random() < (event.probability * freqScale) then
-                    self:_fireEvent(event, now)
-                end
+                table.insert(eligible, event)
             end
+        end
+    end
+    for i = #eligible, 2, -1 do
+        local j = math.random(i)
+        eligible[i], eligible[j] = eligible[j], eligible[i]
+    end
+    for _, event in ipairs(eligible) do
+        if math.random() < (event.probability * freqScale) then
+            self:_fireEvent(event, now)
+            break
         end
     end
 end

--- a/src/events/MDMContractRequestEvent.lua
+++ b/src/events/MDMContractRequestEvent.lua
@@ -38,7 +38,7 @@ function MDMContractRequestEvent:writeStream(streamId, connection)
         streamWriteString(streamId, self.params.fillTypeName)
         streamWriteFloat32(streamId, self.params.quantity)
         streamWriteFloat32(streamId, self.params.lockedPrice)
-        streamWriteFloat64(streamId, self.params.deliveryTimeMs)
+        streamWriteInt32(streamId, math.floor((self.params.deliveryTimeMs or 0) / 1000))
         streamWriteBool(streamId, self.params.isRealDays or false)
         streamWriteFloat32(streamId, self.params.createdTimeScale or 1)
     else
@@ -55,7 +55,7 @@ function MDMContractRequestEvent:readStream(streamId, connection)
         self.params.fillTypeName     = streamReadString(streamId)
         self.params.quantity         = streamReadFloat32(streamId)
         self.params.lockedPrice      = streamReadFloat32(streamId)
-        self.params.deliveryTimeMs   = streamReadFloat64(streamId)
+        self.params.deliveryTimeMs   = streamReadInt32(streamId) * 1000
         self.params.isRealDays       = streamReadBool(streamId)
         self.params.createdTimeScale = streamReadFloat32(streamId)
     else

--- a/src/gui/SettingsUI.lua
+++ b/src/gui/SettingsUI.lua
@@ -235,8 +235,14 @@ function MDMSettingsPanel:requestChange(id, value)
     if id == "debugMode" then
         if MDMLog then MDMLog.debugEnabled = value end
     end
-    
-    -- Optional: broadcast event if needed
+
+    -- Reset world event timer so frequency/enabled changes take effect at the next check
+    -- rather than waiting out the remainder of the current 5-minute interval.
+    if id == "eventFrequency" or id == "eventsEnabled" then
+        if g_MarketDynamics and g_MarketDynamics.worldEvents then
+            g_MarketDynamics.worldEvents.timer = 0
+        end
+    end
 end
 
 -- ── Drawing helpers ───────────────────────────────────────

--- a/src/gui/SettingsUI.lua
+++ b/src/gui/SettingsUI.lua
@@ -89,7 +89,7 @@ local C = {
 -- ── Multi-option definitions ───────────────────────────────
 local MULTI_OPTS = {
     eventFrequency = {
-        values = { 0.4, 1.0, 2.0 },
+        values = { 0.15, 1.0, 2.0 },
         labels = { "mdm_freq_rare", "mdm_freq_normal", "mdm_freq_frequent" },
         i18n   = true,
     },


### PR DESCRIPTION
## Summary

- **#82** — Replace `streamWriteFloat64` (not available on dedicated servers) with `streamWriteInt32` (seconds) in `MDMContractRequestEvent`. Prevents crash when creating contracts in MP.
- **#84** — Remove `addFillLevelFromTool` hook from `PriceHook.lua`. Standard selling stations call both hooks at the same call-stack level, bypassing the re-entrancy guard and double-counting every contract delivery (40% instead of 20%).
- **#88** — Lower Rare event frequency scale from `0.4` → `0.15` (~1 event/hr vs ~2.5/hr). Add per-check cap of 1 new event with Fisher-Yates shuffle to prevent event storms.
- **#90** — Reset `worldEvents.timer` in `MDMSettingsPanel:requestChange()` when `eventFrequency` or `eventsEnabled` changes, so the new setting takes effect at the next 5-minute check instead of waiting out the current interval.

## Test plan

- [ ] Create a futures contract in MP/dedi — no `attempt to call a nil value` crash
- [ ] Deliver a crop against a contract — completion shows correct percentage (not 2×)
- [ ] Set frequency to Rare in settings, observe ~1 event per hour of play, never 2+ events in the same check window
- [ ] Change event frequency while playing — timer resets, new rate takes effect within 5 minutes